### PR TITLE
20260505 #16 prd 2 4 병렬 진행 미니게임 구현 1 2 3번 동시 2배 보너스

### DIFF
--- a/docs/superpowers/plans/2026-05-05-minigame-4-parallel.md
+++ b/docs/superpowers/plans/2026-05-05-minigame-4-parallel.md
@@ -1,0 +1,1383 @@
+# 미니게임 4 "결전의 서막" 병렬 진행 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** PRD §2.4 명세대로 1·2·3번 미니게임을 좌·중·우 3분할 화면에서 동시 진행하고, 합산 점수 ×2 보너스를 적용한 통합 미니게임 (`minigame_4`)을 구현한다.
+
+**Architecture:** 새 컴포넌트 `ParallelGame`이 마스터 phase('idle' / 'running' / 'result')와 마스터 10초 타이머를 통제한다. 기존 `TenSecondsGame` / `ColorReactionGame` / `CatchGame`에 `embedded` 모드 prop을 추가해, 자체 idle/result 패널과 자체 종료 트리거를 비활성화하고 외부에서 phase를 주입받게 한다. 점수 합산·등급 산정은 `parallelUtils.js`로 분리한다.
+
+**Tech Stack:** React 19, Vite 8, vanilla CSS (테스트 인프라 미도입 → 수동 검증 + console.assert)
+
+**Spec:** `docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md`
+
+---
+
+## 파일 구조
+
+| Path | 변경 | 책임 |
+|---|---|---|
+| `src/components/ParallelGame/ParallelGame.jsx` | Create | 마스터 phase / 마스터 타이머 / 점수 합산 / idle·running·result 렌더 |
+| `src/components/ParallelGame/ParallelGame.css` | Create | 3분할 grid 레이아웃, idle/result 패널, HUD |
+| `src/components/ParallelGame/parallelUtils.js` | Create | `getParallelGrade(totalBonus)` + 등급 메타데이터 + console.assert |
+| `src/components/TenSecondsGame/TenSecondsGame.jsx` | Modify | `embedded`, `externalPhase` prop 추가 |
+| `src/components/ColorReactionGame/ColorReactionGame.jsx` | Modify | `embedded`, `externalPhase` prop 추가 (embedded 시 대기 2-6초) |
+| `src/components/CatchGame/CatchGame.jsx` | Modify | `embedded`, `externalPhase`, `speedMultiplier` prop 추가 |
+| `src/App.jsx` | Modify | `state.scene === 'minigame_4'` 분기를 `<ParallelGame />`로 교체 |
+
+---
+
+## Task 1: parallelUtils.js (등급 산정 모듈)
+
+**Files:**
+- Create: `src/components/ParallelGame/parallelUtils.js`
+
+- [ ] **Step 1: 디렉터리 생성 및 파일 작성**
+
+```bash
+mkdir -p src/components/ParallelGame
+```
+
+`src/components/ParallelGame/parallelUtils.js`:
+
+```js
+// 미니게임 4 (병렬 진행) — 합산 점수 → 5단계 등급 산정
+// 1번 max 100 + 2번 max 100 + 3번 max 300 (SPAWN_COUNT 6 × 50) = 합산 max 500
+// × 2 보너스 적용 후 max 1000
+export const PARALLEL_MAX_SCORE = 1000;
+
+export const PARALLEL_GRADES = [
+  { grade: 'LEGENDARY', threshold: 900, stars: 5, color: '#ffd700', title: '🌟 결전의 영웅', desc: '갑옷 입은 그린이의 모든 능력이 폭발했다.' },
+  { grade: 'UNIQUE',    threshold: 750, stars: 4, color: '#ff007f', title: '💎 갑옷의 수호자', desc: '훌륭한 종합 시험. 보스 앞에서도 흔들리지 않으리라.' },
+  { grade: 'EPIC',      threshold: 550, stars: 3, color: '#a78bfa', title: '🔮 결전의 전사', desc: '준비는 충분하다. 보스를 향해 나아가자.' },
+  { grade: 'RARE',      threshold: 300, stars: 2, color: '#60a5fa', title: '⚔️ 시련의 통과자', desc: '아슬아슬하게 시련을 통과했다.' },
+  { grade: 'COMMON',    threshold: 0,   stars: 1, color: '#86efac', title: '🛡️ 새내기 전사', desc: '아직 부족하지만 보스를 향한 첫 발은 뗐다.' },
+];
+
+export function getParallelGrade(totalBonus) {
+  const score = Math.max(0, totalBonus);
+  return PARALLEL_GRADES.find((g) => score >= g.threshold);
+}
+
+// 합산 점수 (보너스 적용 전/후) 산출
+export function computeFinalScore(scoreLeft, scoreCenter, scoreRight, bonus = 2) {
+  const raw = Math.max(0, (scoreLeft ?? 0) + (scoreCenter ?? 0) + (scoreRight ?? 0));
+  return { raw, total: raw * bonus };
+}
+
+// dev 환경 자체 검증 (console.assert)
+if (import.meta.env?.DEV) {
+  console.assert(getParallelGrade(1000).grade === 'LEGENDARY', 'parallelUtils: 1000 → LEGENDARY');
+  console.assert(getParallelGrade(900).grade === 'LEGENDARY', 'parallelUtils: 900 → LEGENDARY');
+  console.assert(getParallelGrade(899).grade === 'UNIQUE',    'parallelUtils: 899 → UNIQUE');
+  console.assert(getParallelGrade(750).grade === 'UNIQUE',    'parallelUtils: 750 → UNIQUE');
+  console.assert(getParallelGrade(749).grade === 'EPIC',      'parallelUtils: 749 → EPIC');
+  console.assert(getParallelGrade(550).grade === 'EPIC',      'parallelUtils: 550 → EPIC');
+  console.assert(getParallelGrade(549).grade === 'RARE',      'parallelUtils: 549 → RARE');
+  console.assert(getParallelGrade(300).grade === 'RARE',      'parallelUtils: 300 → RARE');
+  console.assert(getParallelGrade(299).grade === 'COMMON',    'parallelUtils: 299 → COMMON');
+  console.assert(getParallelGrade(0).grade === 'COMMON',      'parallelUtils: 0 → COMMON');
+  console.assert(getParallelGrade(-100).grade === 'COMMON',   'parallelUtils: -100 → COMMON (clamp)');
+  const f = computeFinalScore(100, 100, 300);
+  console.assert(f.raw === 500 && f.total === 1000, 'parallelUtils: max raw 500, total 1000');
+  const fNeg = computeFinalScore(100, -20, 300);
+  console.assert(fNeg.raw === 380 && fNeg.total === 760, 'parallelUtils: 음수 입력 시 raw 클램프 안 됨 — 380/760');
+  // 주의: 음수 클램프는 합산 raw 단계에서. -20+100+300=380. (음수 입력은 합산 결과로 자연 흡수)
+}
+```
+
+- [ ] **Step 2: 브라우저 콘솔로 self-test 확인**
+
+```bash
+npm run dev
+```
+브라우저 DevTools 콘솔 → `import.meta.env.DEV` 환경에서 console.assert 통과 (실패 시 빨간 에러).
+빠른 검증: `import { getParallelGrade } from './components/ParallelGame/parallelUtils'; getParallelGrade(900);`
+Expected: 콘솔에 assert 에러 없음.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/ParallelGame/parallelUtils.js
+git commit -m "feat: parallelUtils 등급 산정 모듈 추가 #16"
+```
+
+---
+
+## Task 2: TenSecondsGame embedded 모드 추가
+
+**Files:**
+- Modify: `src/components/TenSecondsGame/TenSecondsGame.jsx`
+
+**목표 동작:**
+- `embedded={true}` + `externalPhase="running"` → mount 시 자동 시작 (기존 autoStart 경로 재사용)
+- `externalPhase="result"` 수신 → `cleanup` 호출 + 자체 idle/result 패널 렌더 안 함 + ← 안 눌렀으면 score=0으로 onComplete
+- ← 키 입력은 그대로 동작 (자체 stopGame이 onComplete(score) 호출)
+
+- [ ] **Step 1: 함수 시그니처 + 외부 phase 동기화 effect 추가**
+
+`src/components/TenSecondsGame/TenSecondsGame.jsx` 7-9행 (function signature) 교체:
+
+```jsx
+export default function TenSecondsGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  onComplete,
+  onContinue,
+}) {
+  const [phase, setPhase] = useState("idle");
+```
+
+- [ ] **Step 2: external phase 동기화 effect 추가 (autoStart effect 아래)**
+
+`src/components/TenSecondsGame/TenSecondsGame.jsx` 56행 근처 `useEffect(() => { if (autoStart) ... })` 바로 아래에 추가:
+
+```jsx
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 미보고 시 0점
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phase === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      // 사용자가 ← 안 누르고 마스터 타이머가 종료된 케이스 → 0점 보고
+      cancelAnimationFrame(rafRef.current);
+      setPhase('result');
+      completedRef.current = true;
+      onComplete?.(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [embedded, externalPhase]);
+```
+
+- [ ] **Step 3: render 분기에 embedded 가드 추가**
+
+`src/components/TenSecondsGame/TenSecondsGame.jsx` 95-209행의 `return (...)` 블록에서 controls-area / hint / score-rules / result-panel을 embedded 모드일 때 숨긴다. 95행부터 끝까지의 JSX를 다음과 같이 교체:
+
+```jsx
+  return (
+    <div className={`game-world ${shake ? "world-shake" : ""}`}>
+      <Clouds />
+      <FarBg />
+      <Trees />
+
+      <div className="ground-strip" aria-hidden="true">
+        <div className="ground-grass-row" />
+        <div className="ground-dirt-row" />
+        <div className="ground-sub-row" />
+      </div>
+
+      <div className="game-ground-block">
+        <div className="grass-top" aria-hidden="true">
+          {Array.from({ length: 36 }).map((_, i) => (
+            <div key={i} className={`grass-blade grass-blade-${(i % 6) + 1}`} />
+          ))}
+        </div>
+
+        <div className="game-inner">
+          <div className="sign-board">
+            <span className="sign-icon">⏱</span>
+            <span className="sign-text">10초  맞추기</span>
+            <span className="sign-icon">⏱</span>
+          </div>
+          {!embedded && <p className="sign-subtitle">그린이의 시련 — 정확히 10.00초에 멈춰라!</p>}
+
+          <div className={`timer-board ${timerUrgency}`}>
+            <div className="timer-inner">
+              <span className="timer-digits">
+                {displayTime.toFixed(2)}<span className="timer-unit">s</span>
+              </span>
+            </div>
+            <div className="timer-label">ELAPSED TIME</div>
+          </div>
+
+          {!embedded && (
+            <div className="controls-area">
+              {phase === "idle" && !autoStart && (
+                <button className="pixel-btn pixel-btn-green" onClick={startGame}>
+                  <span>▶ 시작 (← 키)</span>
+                </button>
+              )}
+              {phase === "running" && (
+                <button className="pixel-btn pixel-btn-red" onClick={stopGame}>
+                  <span>◼ 정지 (← 방향키)</span>
+                </button>
+              )}
+              {phase === "result" && (
+                onContinue ? (
+                  <button className="pixel-btn pixel-btn-yellow" onClick={onContinue}>
+                    <span>다음으로 (Enter / Space)</span>
+                  </button>
+                ) : (
+                  <div className="result-btns">
+                    <button className="pixel-btn pixel-btn-yellow" onClick={startGame}>
+                      <span>▶ 다시하기 (Space)</span>
+                    </button>
+                    <button className="pixel-btn pixel-btn-gray" onClick={resetGame}>
+                      <span>↩ 처음으로</span>
+                    </button>
+                  </div>
+                )
+              )}
+            </div>
+          )}
+
+          {!embedded && phase === "idle" && !autoStart && (
+            <>
+              <p className="hint-text">← 키로 타이머를 시작하고,<br />다시 ← 방향키로 정확히 10.00초에 멈추세요!</p>
+              <div className="score-rules">
+                <div className="score-rules-title">📊 판정 기준 (오차 → 보상)</div>
+                <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ 레전더리 (±0.05초)</span><b>+100점</b></div>
+                <div className="score-rule tier-unique"><span>⭐⭐⭐⭐ 유니크 (±0.1초)</span><b>+80점</b></div>
+                <div className="score-rule tier-epic"><span>⭐⭐⭐ 에픽 (±0.2초)</span><b>+60점</b></div>
+                <div className="score-rule tier-rare"><span>⭐⭐ 레어 (±0.4초)</span><b>+40점</b></div>
+                <div className="score-rule tier-common"><span>⭐ 일반 (그 외)</span><b>+20점</b></div>
+              </div>
+            </>
+          )}
+          {!embedded && phase === "running" && (
+            <p className="hint-text running-hint">
+              {displayTime >= 9 ? "🚨 지금이다! 멈춰!!!" : displayTime >= 7 ? "⚠️ 슬슬 준비해..." : "타이머가 흘러가고 있다..."}
+            </p>
+          )}
+
+          {!embedded && phase === "result" && result && (
+            <div className="result-panel" style={{ "--result-color": result.color }}>
+              <div className="result-grade-badge" data-grade={result.grade}>{result.grade}</div>
+              <div className="result-title" style={{ color: result.color }}>{result.title}</div>
+              <StarRating count={result.stars} />
+              <div className="result-stats">
+                <div className="stat-row">
+                  <span className="stat-label">기록 시간</span>
+                  <span className="stat-value">{finalTime.toFixed(3)}s</span>
+                </div>
+                <div className="stat-row">
+                  <span className="stat-label">목표 시간</span>
+                  <span className="stat-value">10.000s</span>
+                </div>
+                <div className="stat-row stat-row-highlight">
+                  <span className="stat-label">오차</span>
+                  <span className="stat-value">{diff < 0.001 ? "PERFECT" : `± ${diff.toFixed(3)}s`}</span>
+                </div>
+                {score !== null && (
+                  <div className="stat-row stat-row-highlight">
+                    <span className="stat-label">점수</span>
+                    <span className="stat-value">+{score}</span>
+                  </div>
+                )}
+              </div>
+              <p className="result-desc">{result.desc}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: 단독 모드 회귀 확인**
+
+```bash
+npm run dev
+```
+브라우저: 콘솔에서 `dispatch({ type: 'GO_TO_SCENE', payload: 'minigame_1' })` 또는 World scene에서 1번 stage 진입 → 기존 idle/result 패널 + ← 키 동작 정상.
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add src/components/TenSecondsGame/TenSecondsGame.jsx
+git commit -m "feat: TenSecondsGame embedded 모드 추가 #16"
+```
+
+---
+
+## Task 3: ColorReactionGame embedded 모드 추가 + 대기 단축
+
+**Files:**
+- Modify: `src/components/ColorReactionGame/ColorReactionGame.jsx`
+
+**목표 동작:**
+- `embedded={true}` + `externalPhase="running"` → 자동 시작 + 대기 시간 **2-6초 랜덤** (단독 모드는 4-10초 유지)
+- `externalPhase="result"` 수신 → cleanup, 자체 패널 숨김, 미보고 시 0점 처리
+- 자체 10초 카운트다운(`gameIntervalRef`)은 embedded 모드에서 비활성
+
+- [ ] **Step 1: 함수 시그니처 변경**
+
+`src/components/ColorReactionGame/ColorReactionGame.jsx` 6행 교체:
+
+```jsx
+export default function ColorReactionGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  onComplete,
+  onContinue,
+}) {
+```
+
+- [ ] **Step 2: startGame 함수에서 embedded 분기 추가**
+
+`src/components/ColorReactionGame/ColorReactionGame.jsx` 31-53행 (`startGame` 콜백)을 다음과 같이 교체:
+
+```jsx
+  const startGame = useCallback(() => {
+    completedRef.current = false;
+    setPhase("waiting");
+    setTimeLeft(10.00);
+    setReactionTime(0);
+
+    // embedded 모드는 자체 10초 카운트다운 비활성 (마스터 타이머가 통제)
+    if (!embedded) {
+      gameIntervalRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 0.01) {
+            endGame("timeout");
+            return 0;
+          }
+          return prev - 0.01;
+        });
+      }, 10);
+    }
+
+    // 단독: 4-10초, embedded: 2-6초 (마스터 10초 안에 react 윈도우 보장)
+    const minDelay = embedded ? 2000 : 4000;
+    const maxDelay = embedded ? 6000 : 10000;
+    const randomDelay = Math.random() * (maxDelay - minDelay) + minDelay;
+    timeoutIdRef.current = setTimeout(() => {
+      setPhase("react");
+      glowStartTimeRef.current = performance.now();
+    }, randomDelay);
+  }, [endGame, embedded]);
+```
+
+- [ ] **Step 3: external phase 동기화 effect 추가**
+
+`src/components/ColorReactionGame/ColorReactionGame.jsx` 81-85행 (`autoStart` effect) 아래에 추가:
+
+```jsx
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 미보고 시 0점
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phase === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      // waiting 중이거나 react 못 누른 상태에서 마스터가 종료 → 0점
+      clearInterval(gameIntervalRef.current);
+      clearTimeout(timeoutIdRef.current);
+      setPhase('timeout');
+      completedRef.current = true;
+      onComplete?.(0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [embedded, externalPhase]);
+```
+
+- [ ] **Step 4: 자체 패널 숨김 (return JSX 수정)**
+
+`src/components/ColorReactionGame/ColorReactionGame.jsx` 101-198행의 return 블록에서 `dungeon-ui-overlay` 내부 패널들을 embedded일 때 숨긴다. 135행부터 시작하는 `<div className="dungeon-ui-overlay">` 블록 내부를 다음과 같이 교체:
+
+```jsx
+      <div className="dungeon-ui-overlay">
+        {!embedded && phase === "idle" && !autoStart && (
+          <div className="dungeon-panel start-panel">
+            <h2 className="dungeon-title">🗿 침묵의 석상</h2>
+            <p>석상의 눈에 <b>붉은 안광</b>이 서리면 ⬆️키를 누르세요!</p>
+            <p className="dungeon-warning">주의: 빛나기 전에 움직이면 즉사합니다.</p>
+            <div className="score-rules">
+              <div className="score-rules-title">📊 판정 기준 (반응 시간 → 보상)</div>
+              <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ 레전더리 (≤150ms)</span><b>+100점</b></div>
+              <div className="score-rule tier-unique"><span>⭐⭐⭐⭐ 유니크 (≤250ms)</span><b>+80점</b></div>
+              <div className="score-rule tier-epic"><span>⭐⭐⭐ 에픽 (≤400ms)</span><b>+60점</b></div>
+              <div className="score-rule tier-rare"><span>⭐⭐ 레어 (≤600ms)</span><b>+40점</b></div>
+              <div className="score-rule tier-common"><span>⭐ 일반 (그 외)</span><b>+20점</b></div>
+              <div className="score-rule score-rule-bad"><span>💥 일찍 누름</span><b>-20점</b></div>
+              <div className="score-rule score-rule-bad"><span>⏰ 시간 초과</span><b>0점</b></div>
+            </div>
+            <button className="dungeon-btn start-btn" onClick={startGame}>
+              ▶ 던전 입장 (↑ 키)
+            </button>
+          </div>
+        )}
+
+        {!embedded && phase === "early" && (
+          <div className="dungeon-panel error-panel">
+            <h2>💥 끔찍한 죽음</h2>
+            <p>석상이 빛나기 전에 움직였습니다!</p>
+            {score !== null && <p style={{ color: '#fca5a5', fontWeight: 'bold' }}>점수: {score}</p>}
+            {onContinue
+              ? <button className="dungeon-btn" onClick={onContinue}>다음으로 (Enter / Space)</button>
+              : <button className="dungeon-btn" onClick={startGame}>다시 도전 (Space)</button>}
+          </div>
+        )}
+
+        {!embedded && phase === "timeout" && (
+          <div className="dungeon-panel error-panel">
+            <h2>⏰ 시간 초과</h2>
+            <p>던전이 무너져 내렸습니다.</p>
+            {score !== null && <p style={{ color: '#fbbf24', fontWeight: 'bold' }}>점수: +{score}</p>}
+            {onContinue
+              ? <button className="dungeon-btn" onClick={onContinue}>다음으로 (Enter / Space)</button>
+              : <button className="dungeon-btn" onClick={startGame}>다시 도전 (Space)</button>}
+          </div>
+        )}
+
+        {!embedded && phase === "result" && resultData && (
+          <div className="dungeon-panel result-panel">
+            <h2 style={{ color: resultData.color }}>{resultData.title}</h2>
+            <h1 className="reaction-time-text">{reactionTime} ms</h1>
+            {score !== null && <p style={{ color: '#fbbf24', fontWeight: 'bold' }}>점수: +{score}</p>}
+            <p className="result-desc">{resultData.desc}</p>
+            {onContinue
+              ? <button className="dungeon-btn" onClick={onContinue}>다음으로 (Enter / Space)</button>
+              : <button className="dungeon-btn" onClick={startGame}>다시 도전 (Space)</button>}
+          </div>
+        )}
+
+        {(phase === "waiting" || phase === "react") && (
+          <div className="instruction-toast">
+            {phase === "waiting" ? "숨을 죽이고 석상을 주시하십시오..." : "지금입니다! ⬆️ 방향키를 누르세요!!"}
+          </div>
+        )}
+      </div>
+```
+
+추가로 101-107행 `dungeon-timer` 표시도 embedded일 때 숨긴다:
+
+```jsx
+      {!embedded && (phase === "waiting" || phase === "react") && (
+        <div className="dungeon-timer">
+          남은 시간: {timeLeft.toFixed(2)}s
+        </div>
+      )}
+```
+
+- [ ] **Step 5: 단독 모드 회귀 확인**
+
+```bash
+npm run dev
+```
+World scene에서 2번 stage 진입 → 기존 idle/result 패널 + ↑ 키 동작 정상. 4-10초 대기 시간 유지.
+
+- [ ] **Step 6: 커밋**
+
+```bash
+git add src/components/ColorReactionGame/ColorReactionGame.jsx
+git commit -m "feat: ColorReactionGame embedded 모드 + 대기 단축 추가 #16"
+```
+
+---
+
+## Task 4: CatchGame embedded 모드 + speedMultiplier 추가
+
+**Files:**
+- Modify: `src/components/CatchGame/CatchGame.jsx`
+
+**목표 동작:**
+- `embedded={true}` + `externalPhase="running"` → 자동 시작
+- `externalPhase="result"` → cleanup + 미보고 시 현재 누적 점수로 onComplete
+- `speedMultiplier=1.5` → 낙하 시간 단축 (`FALL_DURATION_MS / 1.5`), `planSpawnTimes` fallMs 인자 갱신, → 키 거리 판정도 동일 effective duration 사용
+- `FallingItem`에 `speedMultiplier` prop 전달 (기존 컴포넌트가 이미 지원)
+
+- [ ] **Step 1: 함수 시그니처 변경 + effective fall duration 계산**
+
+`src/components/CatchGame/CatchGame.jsx` 21행 교체:
+
+```jsx
+export default function CatchGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  speedMultiplier = 1,
+  onComplete,
+  onContinue,
+}) {
+  const [phase, setPhase] = useState('idle');
+  const [activeItems, setActiveItems] = useState([]);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [score, setScore] = useState(0);
+  const [counts, setCounts] = useState({ perfect: 0, near: 0, fail: 0, miss: 0 });
+  const [feedback, setFeedback] = useState(null);
+
+  const fallDurationMsEffective = FALL_DURATION_MS / speedMultiplier;
+```
+
+- [ ] **Step 2: spawnItem cleanup timeout, planSpawnTimes 호출, → 키 거리 판정에 effective duration 적용**
+
+`src/components/CatchGame/CatchGame.jsx` 71-86행 (`spawnItem` 콜백) 교체:
+
+```jsx
+  const spawnItem = useCallback(() => {
+    const id = nextItemId++;
+    const spawnAt = performance.now() - gameStartMsRef.current;
+    setActiveItems((prev) => [...prev, { id, type: pickRandomType(), spawnAt }]);
+    const tid = setTimeout(() => {
+      setActiveItems((prev) => {
+        const stillThere = prev.some((it) => it.id === id);
+        if (stillThere) {
+          setCounts((c) => ({ ...c, miss: c.miss + 1 }));
+          showFeedback('miss', 'MISS');
+        }
+        return prev.filter((it) => it.id !== id);
+      });
+    }, fallDurationMsEffective + 300);
+    cleanupTimeoutsRef.current.push(tid);
+  }, [showFeedback, fallDurationMsEffective]);
+```
+
+`src/components/CatchGame/CatchGame.jsx` 113-114행 (planSpawnTimes 호출) 교체:
+
+```jsx
+    const schedule = planSpawnTimes(
+      GAME_DURATION_MS,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      fallDurationMsEffective,
+    );
+    spawnTimeoutsRef.current = schedule.map((t) => setTimeout(spawnItem, t));
+```
+
+`src/components/CatchGame/CatchGame.jsx` 152행 (getItemY 호출) 교체:
+
+```jsx
+          const itemCenterY = getItemY(elapsed, STAGE_HEIGHT_PX, fallDurationMsEffective) + ITEM_VISUAL_HEIGHT_PX / 2;
+```
+
+- [ ] **Step 3: external phase 동기화 effect 추가 + endTimeoutRef 비활성**
+
+`src/components/CatchGame/CatchGame.jsx` 120-127행 (endTimeoutRef setTimeout) 교체 — embedded일 때 자체 종료 비활성:
+
+```jsx
+    if (!embedded) {
+      endTimeoutRef.current = setTimeout(() => {
+        cleanupTimers();
+        setPhase('result');
+        if (!completedRef.current) {
+          completedRef.current = true;
+          onComplete?.(scoreRef.current);
+        }
+      }, GAME_DURATION_MS);
+    }
+```
+
+`startGame` 의존성 배열에 `embedded` 추가:
+
+```jsx
+  }, [cleanupTimers, spawnItem, onComplete, embedded]);
+```
+
+`src/components/CatchGame/CatchGame.jsx` 184-189행 (autoStart effect) 아래에 추가:
+
+```jsx
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 누적 점수로 보고
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phaseRef.current === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      cleanupTimers();
+      setPhase('result');
+      completedRef.current = true;
+      onComplete?.(scoreRef.current);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [embedded, externalPhase]);
+```
+
+- [ ] **Step 4: FallingItem에 speedMultiplier 전달**
+
+`src/components/CatchGame/CatchGame.jsx` 204-206행 교체:
+
+```jsx
+      {phase === 'running' && activeItems.map((item) => (
+        <FallingItem key={item.id} type={item.type} speedMultiplier={speedMultiplier} />
+      ))}
+```
+
+- [ ] **Step 5: 자체 패널 숨김 (return JSX의 catch-ui-overlay 영역)**
+
+`src/components/CatchGame/CatchGame.jsx` 218-297행 (`catch-ui-overlay`)에서 idle / result 패널 + 시작 버튼을 embedded일 때 숨긴다. `<div className="catch-ui-overlay">` 블록 내부 시작 부분(218행)부터 끝(297행)까지 교체:
+
+```jsx
+      <div className="catch-ui-overlay">
+        {!embedded && phase === 'idle' && !autoStart && (
+          <div className="catch-panel catch-panel-start">
+            <h2 className="catch-title">⚔️ 장비 드롭의 시련</h2>
+            <p className="catch-subtitle">"흐름을 읽고 잡아내라!"</p>
+            <p>신이 내려주는 장비를 제단(빨간 원) 위치에서 <b>→ 키</b>로 잡아라!</p>
+            <p className="catch-hint">검 ⚔️ · 방패 🛡️ · 포션 🧪 (10초 동안 5개 등장)</p>
+            <div className="score-rules">
+              <div className="score-rules-title">📊 판정 기준 (1회 캐치당)</div>
+              <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ PERFECT (정중앙)</span><b>+50점</b></div>
+              <div className="score-rule tier-rare"><span>⭐⭐ NEAR (근접)</span><b>+20점</b></div>
+              <div className="score-rule score-rule-bad"><span>FAIL / MISS</span><b>0점</b></div>
+              <div className="score-rules-title" style={{ marginTop: 8 }}>🏆 누적 등급 (5개 만점 250)</div>
+              <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ 레전더리</span><b>≥230점</b></div>
+              <div className="score-rule tier-unique"><span>⭐⭐⭐⭐ 유니크</span><b>≥180점</b></div>
+              <div className="score-rule tier-epic"><span>⭐⭐⭐ 에픽</span><b>≥130점</b></div>
+              <div className="score-rule tier-rare"><span>⭐⭐ 레어</span><b>≥80점</b></div>
+              <div className="score-rule tier-common"><span>⭐ 일반</span><b>&lt;80점</b></div>
+            </div>
+            <button className="catch-btn catch-btn-primary" onClick={startGame} type="button">
+              ▶ 시작 (→ 키)
+            </button>
+          </div>
+        )}
+
+        {!embedded && phase === 'running' && (
+          <>
+            <div className="catch-hud">
+              <div className="catch-hud-row">
+                <span>남은 시간</span><b>{remainingSec.toFixed(1)}s</b>
+              </div>
+              <div className="catch-hud-row">
+                <span>점수</span><b>{score}</b>
+              </div>
+            </div>
+            <div className="catch-running-hint">→ 키로 거치대에서 잡아라!</div>
+          </>
+        )}
+
+        {!embedded && phase === 'result' && (() => {
+          const result = getCatchResult(score);
+          const totalJudged = counts.perfect + counts.near + counts.fail + counts.miss;
+          return (
+            <div
+              className="catch-panel catch-panel-result"
+              style={{ '--catch-result-color': result.color }}
+            >
+              <div className="catch-grade-badge" data-grade={result.grade}>{result.grade}</div>
+              <div className="catch-result-title" style={{ color: result.color }}>{result.title}</div>
+              <StarRating count={result.stars} />
+
+              <div className="catch-stats">
+                <div className="catch-stat-row"><span>총점</span><span className="catch-stat-value">+{score}</span></div>
+                <div className="catch-stat-row"><span>완벽 (50점)</span><span>{counts.perfect}</span></div>
+                <div className="catch-stat-row"><span>근접 (20점)</span><span>{counts.near}</span></div>
+                <div className="catch-stat-row"><span>실패 / 놓침</span><span>{counts.fail + counts.miss}</span></div>
+                <div className="catch-stat-row catch-stat-row-highlight"><span>판정 횟수</span><span>{totalJudged}</span></div>
+              </div>
+              <p className="catch-result-desc">{result.desc}</p>
+
+              <div className="catch-result-btns">
+                {onContinue ? (
+                  <button className="catch-btn catch-btn-primary" onClick={onContinue} type="button">
+                    다음으로 (Enter / Space)
+                  </button>
+                ) : (
+                  <>
+                    <button className="catch-btn catch-btn-primary" onClick={startGame} type="button">
+                      ▶ 다시 도전 (Space)
+                    </button>
+                    <button className="catch-btn catch-btn-ghost" onClick={() => setPhase('idle')} type="button">
+                      ↩ 처음으로
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })()}
+      </div>
+```
+
+- [ ] **Step 6: 단독 모드 회귀 확인 (속도 1× 유지 확인)**
+
+```bash
+npm run dev
+```
+World scene에서 3번 stage 진입 → 기존 낙하 속도(`FALL_DURATION_MS=2000ms`) + idle/result 패널 + → 키 동작 정상.
+
+- [ ] **Step 7: 커밋**
+
+```bash
+git add src/components/CatchGame/CatchGame.jsx
+git commit -m "feat: CatchGame embedded 모드 + speedMultiplier 추가 #16"
+```
+
+---
+
+## Task 5: ParallelGame.jsx — idle phase + 마스터 phase 골격
+
+**Files:**
+- Create: `src/components/ParallelGame/ParallelGame.jsx`
+
+**목표 동작:**
+- mount 시 phase 'idle'
+- Space/Enter → phase 'running'
+- (running/result 렌더는 Task 6, 7에서 추가)
+
+- [ ] **Step 1: 컴포넌트 골격 작성 (idle phase만)**
+
+`src/components/ParallelGame/ParallelGame.jsx`:
+
+```jsx
+import { useState, useEffect, useRef, useCallback } from 'react';
+import TenSecondsGame from '../TenSecondsGame/TenSecondsGame';
+import ColorReactionGame from '../ColorReactionGame/ColorReactionGame';
+import CatchGame from '../CatchGame/CatchGame';
+import StarRating from '../TenSecondsGame/StarRating';
+import {
+  PARALLEL_MAX_SCORE,
+  getParallelGrade,
+  computeFinalScore,
+} from './parallelUtils';
+import './ParallelGame.css';
+
+const MASTER_DURATION_MS = 10_000;
+
+export default function ParallelGame({ onComplete, onContinue }) {
+  const [phase, setPhase] = useState('idle'); // 'idle' | 'running' | 'result'
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [scoreLeft, setScoreLeft] = useState(null);
+  const [scoreCenter, setScoreCenter] = useState(null);
+  const [scoreRight, setScoreRight] = useState(null);
+
+  const startMsRef = useRef(0);
+  const rafRef = useRef(null);
+  const masterCompleteRef = useRef(false);
+
+  const startMaster = useCallback(() => {
+    masterCompleteRef.current = false;
+    setScoreLeft(null);
+    setScoreCenter(null);
+    setScoreRight(null);
+    setElapsedMs(0);
+    setPhase('running');
+    startMsRef.current = performance.now();
+  }, []);
+
+  // 키보드: idle → Space/Enter 시작, result → Space/Enter 다음으로
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.code !== 'Space' && e.code !== 'Enter') return;
+      if (phase === 'idle') {
+        e.preventDefault();
+        startMaster();
+      } else if (phase === 'result') {
+        e.preventDefault();
+        onContinue?.();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [phase, startMaster, onContinue]);
+
+  return (
+    <div className="parallel-stage">
+      {phase === 'idle' && (
+        <div className="parallel-idle-panel">
+          <h1 className="parallel-title">⚔️ 결전의 서막</h1>
+          <p className="parallel-subtitle">갑옷을 두른 그린이, 모든 시련을 한 번에</p>
+          <div className="parallel-area-cards">
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">⏱</div>
+              <div className="parallel-area-name">10초 맞추기</div>
+              <div className="parallel-area-key">← 키</div>
+              <div className="parallel-area-max">최대 100점</div>
+            </div>
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">🗿</div>
+              <div className="parallel-area-name">침묵의 석상</div>
+              <div className="parallel-area-key">↑ 키</div>
+              <div className="parallel-area-max">최대 100점</div>
+            </div>
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">⚔️</div>
+              <div className="parallel-area-name">장비 캐치</div>
+              <div className="parallel-area-key">→ 키 (속도 1.5×)</div>
+              <div className="parallel-area-max">최대 300점</div>
+            </div>
+          </div>
+          <p className="parallel-bonus-note">3영역 합산 점수 <b>× 2배 보너스</b> → 최대 {PARALLEL_MAX_SCORE}점</p>
+          <div className="score-rules parallel-grade-rules">
+            <div className="score-rules-title">🏆 등급 (보너스 적용 후 점수)</div>
+            <div className="score-rule tier-legendary"><span>🌟 레전더리</span><b>≥ 900점</b></div>
+            <div className="score-rule tier-unique"><span>💎 유니크</span><b>≥ 750점</b></div>
+            <div className="score-rule tier-epic"><span>🔮 에픽</span><b>≥ 550점</b></div>
+            <div className="score-rule tier-rare"><span>⚔️ 레어</span><b>≥ 300점</b></div>
+            <div className="score-rule tier-common"><span>🛡️ 일반</span><b>&lt; 300점</b></div>
+          </div>
+          <button type="button" className="parallel-start-btn" onClick={startMaster}>
+            ▶ 결전 시작 (Space / Enter)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: App.jsx에 임시 라우팅 (Task 9에서 정식화)** — 여기서는 잠시 직접 import해 idle 패널만 검증
+
+수동 검증을 위해 잠시 App.jsx 67행 (`{state.scene === 'minigame_4' && ...}` 분기)를 다음으로 임시 교체:
+
+```jsx
+import ParallelGame from './components/ParallelGame/ParallelGame';
+// ...
+      {state.scene === 'minigame_4' && (
+        <ParallelGame
+          onComplete={(score) => dispatch({ type: 'ADD_SCORE', payload: score })}
+          onContinue={() => {
+            dispatch({ type: 'SET_WORLD_STAGE', payload: 5 });
+            dispatch({ type: 'GO_TO_SCENE', payload: 'boss_fight' });
+          }}
+        />
+      )}
+```
+
+- [ ] **Step 3: 브라우저로 idle 패널 확인**
+
+```bash
+npm run dev
+```
+World scene에서 4번 stage 진입 → 결전의 서막 idle 패널 표시. Space/Enter → phase 변화 (아직 running UI 미구현이라 빈 화면이 정상).
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/ParallelGame/ParallelGame.jsx src/App.jsx
+git commit -m "feat: ParallelGame idle phase 골격 + App 라우팅 #16"
+```
+
+---
+
+## Task 6: ParallelGame running phase — 3분할 grid + 마스터 타이머
+
+**Files:**
+- Modify: `src/components/ParallelGame/ParallelGame.jsx`
+
+**목표 동작:**
+- phase 'running' 시 RAF 루프로 elapsedMs 갱신, 10초 도달 시 phase 'result' 전환
+- 3분할 grid에 1·2·3번 게임을 embedded로 렌더
+- 상단 HUD에 "남은 시간 X.Xs" 표시
+
+- [ ] **Step 1: RAF 루프 effect 추가**
+
+`src/components/ParallelGame/ParallelGame.jsx`의 `useEffect` (키보드 listener) 아래에 추가:
+
+```jsx
+  // 마스터 타이머: phase 'running' 진입 시 RAF 루프
+  useEffect(() => {
+    if (phase !== 'running') return undefined;
+    const tick = () => {
+      const now = performance.now() - startMsRef.current;
+      setElapsedMs(now);
+      if (now >= MASTER_DURATION_MS) {
+        if (!masterCompleteRef.current) {
+          masterCompleteRef.current = true;
+          setPhase('result');
+        }
+        return;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [phase]);
+```
+
+- [ ] **Step 2: running phase 렌더 추가**
+
+`src/components/ParallelGame/ParallelGame.jsx`의 `return` 블록에서 `{phase === 'idle' && ...}` 다음에 추가:
+
+```jsx
+      {(phase === 'running' || phase === 'result') && (
+        <>
+          <div className="parallel-master-hud">
+            <span className="parallel-master-title">⚔️ 결전의 서막</span>
+            <span className="parallel-master-timer">
+              남은 시간 {Math.max(0, (MASTER_DURATION_MS - elapsedMs) / 1000).toFixed(1)}s
+            </span>
+          </div>
+          <div className="parallel-grid">
+            <div className="parallel-area parallel-area-left">
+              <TenSecondsGame
+                embedded
+                externalPhase={phase}
+                onComplete={(score) => setScoreLeft(score)}
+              />
+            </div>
+            <div className="parallel-area parallel-area-center">
+              <ColorReactionGame
+                embedded
+                externalPhase={phase}
+                onComplete={(score) => setScoreCenter(score)}
+              />
+            </div>
+            <div className="parallel-area parallel-area-right">
+              <CatchGame
+                embedded
+                externalPhase={phase}
+                speedMultiplier={1.5}
+                onComplete={(score) => setScoreRight(score)}
+              />
+            </div>
+          </div>
+        </>
+      )}
+```
+
+- [ ] **Step 3: 브라우저 확인 (running 동작)**
+
+```bash
+npm run dev
+```
+4번 stage 진입 → idle → Space → 3분할 동시 진행 (스타일 미적용이라 레이아웃은 깨질 수 있음, 동작만 확인). ←/↑/→ 키 입력 시 각 영역 반응.
+콘솔에서 `setScoreLeft`, `setScoreCenter`, `setScoreRight` 호출이 onComplete로 들어오는지 React DevTools로 확인.
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/ParallelGame/ParallelGame.jsx
+git commit -m "feat: ParallelGame running phase + 마스터 타이머 #16"
+```
+
+---
+
+## Task 7: ParallelGame result phase — 합산 + 등급 + onContinue
+
+**Files:**
+- Modify: `src/components/ParallelGame/ParallelGame.jsx`
+
+**목표 동작:**
+- phase 'result' 진입 시점에 미보고 영역(null)은 0으로 확정 → totalRaw, totalBonus 계산 → onComplete(totalBonus) 1회 호출
+- 결과 패널에 영역별 점수 + 합산 + 보너스 + 등급 + StarRating 표시
+
+- [ ] **Step 1: result 합산 effect 추가**
+
+`src/components/ParallelGame/ParallelGame.jsx`의 RAF effect 아래에 추가:
+
+```jsx
+  const resultCompleteRef = useRef(false);
+
+  // result 진입 시점: 미보고 영역 0 처리 + onComplete 1회 호출
+  useEffect(() => {
+    if (phase !== 'result') return;
+    if (resultCompleteRef.current) return;
+    resultCompleteRef.current = true;
+    const l = scoreLeft ?? 0;
+    const c = scoreCenter ?? 0;
+    const r = scoreRight ?? 0;
+    const { total } = computeFinalScore(l, c, r);
+    onComplete?.(total);
+  }, [phase, scoreLeft, scoreCenter, scoreRight, onComplete]);
+```
+
+> **주의**: onComplete가 호출되는 시점에는 마스터 phase=result로 인해 각 sub-component도 externalPhase=result를 받아 자체 onComplete를 호출 중일 수 있다. 그러나 sub-component는 `completedRef` 가드로 1회 한정이므로 race condition은 최종 score 값에 영향이 없다. setState batching으로 마지막 setScore* 호출이 반영된 시점의 effect 발화를 사용한다.
+
+- [ ] **Step 2: result 패널 렌더 추가**
+
+`src/components/ParallelGame/ParallelGame.jsx`의 `return` 블록에서 `{(phase === 'running' || phase === 'result') && ...}` 블록 **뒤에** 추가:
+
+```jsx
+      {phase === 'result' && (() => {
+        const l = scoreLeft ?? 0;
+        const c = scoreCenter ?? 0;
+        const r = scoreRight ?? 0;
+        const { raw, total } = computeFinalScore(l, c, r);
+        const grade = getParallelGrade(total);
+        return (
+          <div className="parallel-result-overlay">
+            <div
+              className="parallel-result-panel"
+              style={{ '--parallel-result-color': grade.color }}
+            >
+              <div className="parallel-grade-badge" data-grade={grade.grade}>{grade.grade}</div>
+              <div className="parallel-result-title" style={{ color: grade.color }}>{grade.title}</div>
+              <StarRating count={grade.stars} />
+
+              <div className="parallel-stats">
+                <div className="parallel-stat-row"><span>좌 (10초 맞추기)</span><b>+{l}</b></div>
+                <div className="parallel-stat-row"><span>중 (색상 반응)</span><b>{c >= 0 ? `+${c}` : c}</b></div>
+                <div className="parallel-stat-row"><span>우 (캐치 1.5×)</span><b>+{r}</b></div>
+                <div className="parallel-stat-divider" />
+                <div className="parallel-stat-row"><span>합산</span><b>+{raw}</b></div>
+                <div className="parallel-stat-row"><span>× 2 보너스</span><b>+{total}</b></div>
+                <div className="parallel-stat-divider" />
+                <div className="parallel-stat-row parallel-stat-row-highlight">
+                  <span>최종 점수</span><b>+{total}</b>
+                </div>
+              </div>
+              <p className="parallel-result-desc">{grade.desc}</p>
+              <button type="button" className="parallel-continue-btn" onClick={onContinue}>
+                다음으로 (Enter / Space)
+              </button>
+            </div>
+          </div>
+        );
+      })()}
+```
+
+- [ ] **Step 3: 브라우저 동작 확인 (result 진입)**
+
+```bash
+npm run dev
+```
+4번 stage 진입 → Space → 10초 후 result 패널 등장 → 점수/등급 표시. Enter/Space → boss_fight 씬 전환. (스타일은 다음 Task에서 정리)
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add src/components/ParallelGame/ParallelGame.jsx
+git commit -m "feat: ParallelGame result phase + 합산/등급 표시 #16"
+```
+
+---
+
+## Task 8: ParallelGame.css — 3분할 grid + idle/result 패널 스타일
+
+**Files:**
+- Create: `src/components/ParallelGame/ParallelGame.css`
+
+- [ ] **Step 1: CSS 작성**
+
+`src/components/ParallelGame/ParallelGame.css`:
+
+```css
+/* 미니게임 4 — 결전의 서막 (병렬 진행) */
+
+.parallel-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 60%, #0f172a 100%);
+  color: #e2e8f0;
+  overflow: hidden;
+}
+
+/* ─── Idle 패널 ─────────────────────────────── */
+.parallel-idle-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 40px;
+  text-align: center;
+}
+.parallel-title {
+  font-size: 56px;
+  margin: 0;
+  color: #fbbf24;
+  text-shadow: 2px 2px 0 #000, 0 0 16px rgba(251, 191, 36, 0.5);
+}
+.parallel-subtitle {
+  font-size: 22px;
+  color: #94a3b8;
+  margin: 0 0 8px;
+}
+.parallel-area-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  width: min(900px, 90%);
+}
+.parallel-area-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 2px solid #475569;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+.parallel-area-icon  { font-size: 40px; }
+.parallel-area-name  { font-size: 18px; font-weight: 700; }
+.parallel-area-key   { font-size: 14px; color: #fbbf24; }
+.parallel-area-max   { font-size: 13px; color: #94a3b8; }
+
+.parallel-bonus-note {
+  font-size: 18px;
+  color: #fbbf24;
+  margin: 0;
+}
+.parallel-grade-rules {
+  width: min(560px, 90%);
+}
+.parallel-start-btn {
+  margin-top: 12px;
+  padding: 14px 32px;
+  font-size: 20px;
+  font-weight: 700;
+  background: linear-gradient(180deg, #fbbf24, #d97706);
+  color: #1f2937;
+  border: 3px solid #92400e;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #78350f;
+}
+.parallel-start-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 #78350f;
+}
+.parallel-start-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #78350f;
+}
+
+/* ─── Running phase: HUD + 3분할 grid ─────── */
+.parallel-master-hud {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 32px;
+  background: rgba(15, 23, 42, 0.85);
+  border-bottom: 3px solid #fbbf24;
+  z-index: 10;
+}
+.parallel-master-title  { font-size: 22px; font-weight: 700; color: #fbbf24; }
+.parallel-master-timer  { font-size: 22px; font-weight: 700; color: #f1f5f9; font-variant-numeric: tabular-nums; }
+
+.parallel-grid {
+  position: absolute;
+  top: 64px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0;
+}
+.parallel-area {
+  position: relative;
+  overflow: hidden;
+  border-right: 2px solid rgba(251, 191, 36, 0.3);
+}
+.parallel-area:last-child { border-right: none; }
+
+/* sub-component의 stage가 자기 영역에 맞도록 강제 */
+.parallel-area > * {
+  width: 100%;
+  height: 100%;
+}
+
+/* ─── Result 패널 ─────────────────────────── */
+.parallel-result-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 20;
+}
+.parallel-result-panel {
+  background: linear-gradient(180deg, #1e293b, #0f172a);
+  border: 3px solid var(--parallel-result-color, #fbbf24);
+  border-radius: 16px;
+  padding: 32px 40px;
+  max-width: 520px;
+  text-align: center;
+  box-shadow: 0 0 40px var(--parallel-result-color, #fbbf24);
+}
+.parallel-grade-badge {
+  display: inline-block;
+  padding: 6px 18px;
+  background: var(--parallel-result-color);
+  color: #1f2937;
+  font-weight: 700;
+  border-radius: 999px;
+  font-size: 14px;
+  letter-spacing: 1px;
+  margin-bottom: 12px;
+}
+.parallel-result-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 12px;
+}
+.parallel-stats {
+  margin: 20px 0 16px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.parallel-stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 16px;
+}
+.parallel-stat-row b { color: #fbbf24; }
+.parallel-stat-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 4px 0;
+}
+.parallel-stat-row-highlight {
+  font-size: 20px;
+  font-weight: 700;
+}
+.parallel-stat-row-highlight b { color: var(--parallel-result-color); }
+.parallel-result-desc {
+  margin: 8px 0 16px;
+  color: #cbd5e1;
+}
+.parallel-continue-btn {
+  padding: 12px 28px;
+  font-size: 18px;
+  font-weight: 700;
+  background: linear-gradient(180deg, #fbbf24, #d97706);
+  color: #1f2937;
+  border: 3px solid #92400e;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #78350f;
+}
+.parallel-continue-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 #78350f;
+}
+.parallel-continue-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #78350f;
+}
+```
+
+- [ ] **Step 2: 브라우저로 레이아웃 확인**
+
+```bash
+npm run dev
+```
+4번 stage 진입 → idle 패널 카드 3개 + 등급표 + 시작 버튼 정상 → Space → 상단 HUD + 3분할 grid (각 영역에 sub 게임이 자기 영역으로 채워짐) → 10초 후 result 패널 (등급별 색상 적용) → Enter → boss_fight.
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add src/components/ParallelGame/ParallelGame.css
+git commit -m "style: ParallelGame 3분할 grid + idle/result 패널 #16"
+```
+
+---
+
+## Task 9: App.jsx 정식 라우팅 (Task 5에서 이미 적용 시 confirm only)
+
+**Files:**
+- Modify: `src/App.jsx`
+
+> Task 5 Step 2에서 이미 라우팅을 교체했다면 이 Task는 검증 + 커밋만 진행. 별개 커밋이 필요하지 않으면 건너뛰어도 됨.
+
+- [ ] **Step 1: import 및 분기 확인**
+
+`src/App.jsx` 상단 import에 `ParallelGame`이 포함되어 있는지 확인:
+
+```jsx
+import ParallelGame from './components/ParallelGame/ParallelGame';
+```
+
+`state.scene === 'minigame_4'` 분기가 다음 형태인지 확인 (60-66행 근처):
+
+```jsx
+      {state.scene === 'minigame_4' && (
+        <ParallelGame
+          onComplete={(score) => dispatch({ type: 'ADD_SCORE', payload: score })}
+          onContinue={() => {
+            dispatch({ type: 'SET_WORLD_STAGE', payload: 5 });
+            dispatch({ type: 'GO_TO_SCENE', payload: 'boss_fight' });
+          }}
+        />
+      )}
+```
+
+기존 `<PlaceholderScene title="⚔️ 미니게임 4: 병렬 진행" ...>`은 제거되었어야 함.
+
+- [ ] **Step 2: lint 통과 확인**
+
+```bash
+npm run lint
+```
+Expected: 신규/수정 파일에 lint 에러 없음.
+
+- [ ] **Step 3: Task 5에서 미커밋이면 커밋, 이미 커밋되었으면 skip**
+
+```bash
+git status
+# 변경이 있다면:
+git add src/App.jsx
+git commit -m "feat: App.jsx minigame_4 placeholder → ParallelGame 라우팅 #16"
+```
+
+---
+
+## Task 10: 수동 테스트 시나리오 검증
+
+**Files:** (테스트 전용, 코드 변경 없음)
+
+- [ ] **Step 1: 시나리오 1 — 만점 근접 (레전더리)**
+
+브라우저에서 World scene → 4번 stage 진입 → Space로 시작.
+- 좌: 10.0초 정확히 ← 누름 (최대 100점)
+- 중: glow 후 빠르게 ↑ 누름 (≤150ms 목표 → 100점)
+- 우: 6개 모두 perfect (300점)
+- Expected: result 패널에 합산 500, ×2=1000, 🌟 LEGENDARY 등급, gold 색상
+
+- [ ] **Step 2: 시나리오 2 — 1번 미입력 (유니크)**
+
+4번 stage 재진입 → Space → 좌(←) 안 누름, 중·우 만점.
+- 좌 0 + 중 100 + 우 300 = 400 → ×2 = 800
+- Expected: 💎 UNIQUE 등급. 좌 영역 점수 표시 +0.
+
+- [ ] **Step 3: 시나리오 3 — 2번 일찍 누름 (유니크)**
+
+4번 stage 재진입 → Space → 중(↑) phase 'waiting'에서 미리 누름 → -20점. 좌·우 만점.
+- 좌 100 + 중 -20 + 우 300 = 380 → ×2 = 760
+- Expected: 💎 UNIQUE 등급, 중 영역 점수 표시 -20 (음수 표시 확인). 합산은 380 (음수 클램프 미적용 — 합산이 양수이므로 그대로).
+
+- [ ] **Step 4: 시나리오 4 — 모두 0점 (일반)**
+
+4번 stage 재진입 → Space → 아무 키도 안 누르고 10초 흐르게 둠.
+- 좌 0 + 중 0 + 우 0 = 0 → ×2 = 0
+- Expected: 🛡️ COMMON 등급 (green 색상)
+
+- [ ] **Step 5: 시나리오 5 — 동시 키 입력**
+
+4번 stage 재진입 → Space → ←↑→ 동시 누르기 시도.
+- Expected: 각 영역이 독립적으로 자기 키만 반응. 좌는 stop, 중은 react/early, 우는 caught 동작.
+
+- [ ] **Step 6: 시나리오 6 — 씬 전환**
+
+result 패널에서 Enter 키 (또는 "다음으로" 버튼 클릭).
+- Expected: `boss_fight` 씬으로 전환 (Placeholder 화면 표시).
+
+- [ ] **Step 7: 단독 모드 회귀**
+
+각 미니게임 단독 진입 (1·2·3번 stage)에서 기존 동작 정상 동작 확인:
+- 1번: ←로 시작/정지, idle/result 패널 정상
+- 2번: ↑로 react, 4-10초 대기 유지, idle/result 패널 정상
+- 3번: → 캐치, 낙하 속도 1× (느린 기존 속도) 유지, idle/result 패널 정상
+
+- [ ] **Step 8: 콘솔 console.assert 검증**
+
+DevTools 콘솔에서 빨간색 assert 에러가 없는지 확인 (parallelUtils의 dev self-test).
+
+- [ ] **Step 9: 커밋 (선택, 변경 없으면 skip)**
+
+수동 테스트는 커밋 없음. 시나리오 결과는 PR 본문에 기재.
+
+---
+
+## 완료 기준
+
+- [ ] Task 1-9 코드 변경 모두 커밋됨
+- [ ] Task 10 수동 시나리오 6개 모두 통과
+- [ ] `npm run lint` 통과
+- [ ] 단독 모드 미니게임 1·2·3번 회귀 없음
+- [ ] App.jsx의 `minigame_4` 분기가 더 이상 PlaceholderScene을 렌더하지 않음
+
+---
+
+## 참고
+
+- 스펙: `docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md`
+- 이슈: `.issues/20260505_기능추가_미니게임4_병렬_진행_구현.md`
+- 선행 스펙: `docs/superpowers/specs/2026-05-04-scene-routing-design.md`, `2026-05-04-minigame-stage-expand-design.md`

--- a/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
+++ b/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
@@ -1,0 +1,337 @@
+# 미니게임 4 "결전의 서막" — 병렬 진행 미니게임 설계
+
+- **이슈**: #16 [기능추가][미니게임4] PRD §2.4 병렬 진행 미니게임 구현 (1+2+3번 동시 + 2배 보너스)
+- **컨셉**: 결전의 서막 — *"갑옷을 두른 그린이, 모든 시련을 한 번에"*
+- **위치**: `armor` 씬 직후, `boss_fight` 씬 직전
+- **작성일**: 2026-05-05
+
+---
+
+## 1. 목적과 배경
+
+이슈 #12 작업으로 scene routing은 완성되었으나 4번 미니게임은 placeholder 화면(제목 + "다음으로" 버튼)만 마련된 상태다. 갑옷을 장착한 그린이가 진행해야 할 클라이맥스 단계인데 실제 게임 로직이 없어 스토리상 빈 단계로 남아있다.
+
+PRD §2.4 명세는 1·2·3번을 한 화면에서 동시 진행, 점수 2배, 캐치 속도 1.5배다. 1·2·3번이 "연습/시련"이라면 4번은 갑옷 입은 그린이가 모든 능력(시간 감각·반사신경·동체시력)을 동시에 발휘하는 **결전 직전의 종합 시험**이다.
+
+---
+
+## 2. 요구사항
+
+### 기능 요구사항
+
+- 좌·중·우 3분할 레이아웃에서 1·2·3번 미니게임을 동시 진행
+  - 좌: 10초 맞추기 (← 키)
+  - 중: 색상 반응 (↑ 키)
+  - 우: 캐치 (→ 키, **속도 1.5배**)
+- 게임 시간 10초로 통일된 마스터 타이머
+- 3영역 점수 합산 → **× 2 보너스 적용**
+- 결과 패널에 영역별 점수 + 합산 + 보너스 + 5단계 등급 표시
+- App.jsx 라우터에서 `minigame_4` placeholder를 실제 컴포넌트로 교체
+- onContinue → `boss_fight` 씬 전환
+
+### 비기능 요구사항
+
+- 1·2·3번 게임 컴포넌트의 게임 로직(점수/판정) 재사용 (코드 중복 금지)
+- 5단계 등급 시스템 (레전더리/유니크/에픽/레어/일반) 그대로 사용
+- Stage 1920×960 base + transform scale fit (다른 미니게임과 일관)
+- gameStore.scene 기반 라우팅 패턴 유지 (외부 라우터 도입 금지)
+
+### 비범위 (Out of Scope)
+
+- 갑옷/검 스프라이트(`walk_weapon`) 시각 적용 — 별도 갑옷 이슈에서 처리되면 자연 연동
+- 보스전 데미지 산출 로직 — 본 이슈는 점수 합산까지만 담당
+- 1·2·3번 단독 진입 미니게임의 동작 변경 — embedded 모드 추가만, 기존 동작 유지
+
+---
+
+## 3. 아키텍처
+
+### 3.1 새 컴포넌트
+
+```
+src/components/ParallelGame/
+├── ParallelGame.jsx          # 마스터 오케스트레이터 (idle/running/result)
+├── ParallelGame.css          # 3분할 레이아웃 + 결과 패널
+└── parallelUtils.js          # getParallelGrade(totalBonus) + 등급 메타
+```
+
+### 3.2 기존 컴포넌트 확장 — `embedded` 모드
+
+`TenSecondsGame`, `ColorReactionGame`, `CatchGame`에 다음 prop을 추가한다:
+
+| Prop | Type | 기본값 | 설명 |
+|---|---|---|---|
+| `embedded` | boolean | `false` | true일 때 자체 idle/result 패널을 숨기고 자체 종료 타이머 비활성화 |
+| `externalPhase` | `'idle' \| 'running' \| 'result'` | undefined | embedded일 때 외부에서 phase 주입 (마스터 타이머가 통제) |
+| `speedMultiplier` (CatchGame 전용) | number | `1` | FALL_DURATION_MS와 planSpawnTimes 결과를 분할해 낙하 속도 가속 |
+
+**embedded 모드 동작**:
+- 자체 idle/result 패널 렌더링 생략 (running phase의 게임 stage UI만 렌더)
+- `externalPhase === 'running'`이 들어오면 자동 시작 (mount 직후 또는 phase 변화 시점)
+- 자체 종료 트리거 비활성화 — 게임 종료는 오직 `externalPhase === 'result'` 수신으로만 발생:
+  - `TenSecondsGame`: 자체 종료 트리거는 ← 키 한정. 마스터가 'result' 전파하면 그 시점의 finalTime/score를 확정 (← 안 눌렀으면 score=0)
+  - `ColorReactionGame`: 자체 10초 카운트다운(`gameIntervalRef`) 비활성화. 마스터 'result' 시점에 cleanup
+  - `CatchGame`: `endTimeoutRef` 비활성화. 마스터 'result' 시점에 cleanup. `cleanupTimeoutsRef` (아이템 자동 제거 timeout)는 유지 — 시각 정리용
+- `externalPhase === 'result'` 수신 시 컴포넌트는 자체 cleanup 함수를 호출하고 미보고 score를 확정 (1회 한정 onComplete)
+- 자체 keydown listener는 그대로 유지 (←/↑/→ 키가 다르므로 충돌 없음, Enter/Space는 embedded일 때 무시)
+- `onComplete(score)`은 기존대로 1회 호출 (`completedRef` 가드)
+
+### 3.3 데이터 흐름
+
+```
+ParallelGame (마스터)
+├─ phase: 'idle' → Space/Enter → 'running' → 10초 후 'result'
+├─ scoreLeft / scoreCenter / scoreRight (각 영역 onComplete로 수집)
+├─ totalRaw = clamp(L+C+R, ≥0)
+├─ totalBonus = totalRaw × 2
+├─ grade = getParallelGrade(totalBonus)
+└─ Renders:
+   ├─ Phase 'idle': 통합 안내 패널
+   ├─ Phase 'running': 3분할 grid
+   │   ├─ Left:   <TenSecondsGame embedded externalPhase="running" onComplete={setScoreLeft} />
+   │   ├─ Center: <ColorReactionGame embedded externalPhase="running" onComplete={setScoreCenter} />
+   │   └─ Right:  <CatchGame embedded externalPhase="running" speedMultiplier={1.5} onComplete={setScoreRight} />
+   └─ Phase 'result': 통합 결과 패널
+```
+
+### 3.4 라우터 연결
+
+```jsx
+// App.jsx
+{state.scene === 'minigame_4' && (
+  <ParallelGame
+    onComplete={(score) => dispatch({ type: 'ADD_SCORE', payload: score })}
+    onContinue={() => {
+      dispatch({ type: 'SET_WORLD_STAGE', payload: 5 });
+      dispatch({ type: 'GO_TO_SCENE', payload: 'boss_fight' });
+    }}
+  />
+)}
+```
+
+---
+
+## 4. 타이밍과 키보드
+
+### 4.1 마스터 타이머
+
+- `ParallelGame`은 phase 'running' 진입 시점에 `startMs = performance.now()` 기록
+- `requestAnimationFrame` 루프로 `elapsedMs` 갱신 → 상단 HUD에 "남은 시간 X.Xs" 표시
+- `elapsedMs >= 10000`이 되면 phase 'result'로 전환
+- 각 영역의 자체 종료는 `externalPhase="result"` 전파로만 트리거됨 (자체 endTimeout 비활성화)
+
+### 4.2 키보드 입력 분리
+
+- 각 게임 컴포넌트의 기존 `window keydown` listener 그대로 유지
+- ←, ↑, → 키 코드가 달라 자연스럽게 분리됨 (동시 입력 시 각 영역 독립 처리)
+- `ParallelGame`은 별도 listener:
+  - Phase 'idle' + Space/Enter → phase 'running'으로 전환
+  - Phase 'result' + Space/Enter → `onContinue()` 호출
+
+### 4.3 진입 키 잔류 방지
+
+- 4번 씬 진입은 World에서 발생하므로 idle 패널 시작 키(Space/Enter)는 잔류 위험 없음
+- 기존 `CatchGame`의 `rightKeyArmedRef` 패턴은 그대로 유지 (혹시 모를 케이스 대비)
+
+---
+
+## 5. 게임별 동작 디테일
+
+### 5.1 1번 — 10초 맞추기 (좌)
+
+- mount + `externalPhase="running"` → `startGame()` 자동 호출
+- ← 키 누르면 finalTime 기록 → `onComplete(getScore(diff))` 즉시 호출
+- 사용자가 ← 안 누르고 마스터 10초 끝남 → `onComplete` 미호출 → ParallelGame이 phase 'result' 시점에 `scoreLeft = 0` 적용
+- 영역 안에서는 타이머 디지트와 elapsed time만 표시
+
+### 5.2 2번 — 색상 반응 (중)
+
+- mount + `externalPhase="running"` → `startGame()` 호출
+- ⚠️ 기존 대기 시간 4-10초는 마스터 10초 안에 react 윈도우가 안 생길 수 있음
+  - **embedded 모드 한정**: 대기 시간을 **2-6초 랜덤**으로 단축 (반응 윈도우 4-8초 보장)
+- 일찍 ↑ 누름 → `-20점`
+- 시간 초과 → `0점`
+- 정상 react → `getScore(reactionTime)` (100/80/60/40/20)
+
+### 5.3 3번 — 캐치 (우)
+
+- mount + `externalPhase="running"` + `speedMultiplier=1.5` → `startGame()` 호출
+- `FALL_DURATION_MS_EFFECTIVE = FALL_DURATION_MS / 1.5` (낙하 가속)
+- `planSpawnTimes()` 결과도 동일 비율로 단축 → 10초 내 5개 등장 유지
+- → 키 처리 그대로
+
+---
+
+## 6. 점수와 등급
+
+### 6.1 점수 합산
+
+- 영역별 score는 `ParallelGame`의 로컬 state로 누적
+- Phase 'result' 진입 시점에:
+  - 미보고 영역(예: 1번 ← 안 누름)은 `0` 강제 적용
+  - `totalRaw = Math.max(0, scoreLeft + scoreCenter + scoreRight)` (음수 클램프)
+  - `totalBonus = totalRaw × 2`
+  - `onComplete(totalBonus)` 호출 → gameStore에 가산
+  - `getParallelGrade(totalBonus)`로 등급 산정
+
+### 6.2 5단계 등급 임계치
+
+각 영역 max 점수: 1번 100 + 2번 100 + 3번 250 = **합산 max 450** → **× 2 보너스 max 900**
+
+| 등급 | 색상 | 별 | 임계치 (max 900) | % |
+|---|---|---|---|---|
+| 🌟 레전더리 | `#fbbf24` (gold) | ⭐⭐⭐⭐⭐ | ≥ 810 | ≥ 90% |
+| 💎 유니크 | `#a78bfa` (purple) | ⭐⭐⭐⭐ | ≥ 675 | ≥ 75% |
+| 🔮 에픽 | `#60a5fa` (blue) | ⭐⭐⭐ | ≥ 495 | ≥ 55% |
+| ⚔️ 레어 | `#34d399` (green) | ⭐⭐ | ≥ 270 | ≥ 30% |
+| 🛡️ 일반 | `#9ca3af` (gray) | ⭐ | < 270 | < 30% |
+
+### 6.3 `parallelUtils.js` 시그니처
+
+```js
+export const PARALLEL_MAX_SCORE = 900;
+export const PARALLEL_GRADES = [
+  { grade: '레전더리', threshold: 810, stars: 5, color: '#fbbf24', title: '🌟 결전의 영웅' },
+  { grade: '유니크',   threshold: 675, stars: 4, color: '#a78bfa', title: '💎 갑옷의 수호자' },
+  { grade: '에픽',     threshold: 495, stars: 3, color: '#60a5fa', title: '🔮 결전의 전사' },
+  { grade: '레어',     threshold: 270, stars: 2, color: '#34d399', title: '⚔️ 시련의 통과자' },
+  { grade: '일반',     threshold: 0,   stars: 1, color: '#9ca3af', title: '🛡️ 새내기 전사' },
+];
+
+export function getParallelGrade(totalBonus) {
+  const score = Math.max(0, totalBonus);
+  return PARALLEL_GRADES.find(g => score >= g.threshold);
+}
+```
+
+---
+
+## 7. UI 레이아웃
+
+### 7.1 Stage (1920×960 base)
+
+```
+┌─────────────────────────────────────────────────┐
+│  [상단 HUD: 결전의 서막  |  남은 시간 7.3s]     │  ← 80px
+├──────────────┬──────────────┬───────────────────┤
+│              │              │                   │
+│   [1번]      │   [2번]      │     [3번]         │
+│  10초맞추기  │  색상반응     │     캐치          │  ← 880px
+│   (←)        │   (↑)        │     (→ × 1.5x)   │
+│              │              │                   │
+└──────────────┴──────────────┴───────────────────┘
+   width: 33.3%   33.3%          33.3%
+```
+
+- CSS Grid 3-column (`grid-template-columns: 1fr 1fr 1fr`)
+- 각 영역의 game stage는 transform scale로 자기 영역에 맞게 축소 (overflow hidden)
+- 상단 HUD는 `position: absolute; top: 0;`로 영역 위에 띄움
+
+### 7.2 Idle 패널
+
+- 전체 화면 단일 패널, 어두운 배경 위에 카드
+- 제목: **"⚔️ 결전의 서막"**
+- 부제: *"갑옷을 두른 그린이, 모든 시련을 한 번에"*
+- 3개 영역 게임 미니카드 (좌·중·우):
+  - 좌: ⏱ 10초 맞추기 / ← 키
+  - 중: 🗿 침묵의 석상 / ↑ 키
+  - 우: ⚔️ 장비 캐치 / → 키 (속도 1.5×)
+- 보너스 안내: **"3영역 합산 점수 × 2배 보너스"**
+- 등급표 (5단계, max 900 기준) — 기존 `.score-rules` + `tier-*` 클래스 재사용
+- 시작 버튼: "▶ 결전 시작 (Space / Enter)"
+
+### 7.3 Result 패널
+
+```
+   [등급 배지: 레전더리 🌟]
+   "결전의 영웅"
+   ⭐⭐⭐⭐⭐
+
+   ┌─────────────────────────┐
+   │ 좌 (10초 맞추기)   +80  │
+   │ 중 (색상 반응)     +60  │
+   │ 우 (캐치)         +180  │
+   ├─────────────────────────┤
+   │ 합산              +320  │
+   │ × 2 보너스        +640  │
+   ├─────────────────────────┤
+   │ 최종 점수         +640  │  ← highlight
+   └─────────────────────────┘
+
+   [다음으로 (Enter / Space)]
+```
+
+- 기존 미니게임 result 패널 스타일 재사용 (`.result-panel`, `tier-*` 색상 토큰)
+- `StarRating` 컴포넌트 재사용 (`TenSecondsGame/StarRating.jsx`)
+
+---
+
+## 8. 에러 / 엣지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| 1번 ← 안 누름 | scoreLeft 미보고 → 'result' 시점에 `0` 적용 |
+| 2번 일찍 ↑ 누름 | 기존 로직: `-20`점. `totalRaw` 합산 시 `Math.max(0, ...)`로 클램프 |
+| 2번 시간 초과 | 0점. embedded 대기 2-6초 단축으로 react 윈도우 보장 |
+| 3번 캐치 일부 놓침 | 기존 로직: 놓친 아이템 0점 |
+| onComplete 중복 호출 | 각 컴포넌트의 `completedRef` 가드로 1회만 호출 (기존 패턴 유지) |
+| 마스터 타이머 vs 자체 종료 충돌 | embedded 모드에서 자체 endTimeout/timer 비활성화. 종료는 `externalPhase`로만 트리거 |
+| 진입 키 잔류 | idle → Space/Enter 시작이라 ←/↑/→ 잔류 무관. CatchGame `rightKeyArmedRef` 패턴 유지 |
+| 점수 음수 (2번 -20) | `Math.max(0, totalBonus)`로 클램프 후 등급 산정 |
+
+---
+
+## 9. 테스트 전략
+
+### 9.1 유닛 테스트 (`parallelUtils.test.js`)
+
+- `getParallelGrade(score)` 임계치 경계: 810, 809, 675, 495, 270, 269, 0, 음수
+- 각 등급별 색상/타이틀/별 개수 매핑 검증
+
+### 9.2 수동 / 통합 테스트 (브라우저)
+
+Vite dev 서버에서 `state.scene = 'minigame_4'` 진입 후 6개 시나리오:
+
+1. **만점**: 모든 영역 만점 → 합산 450 ×2 = 900 → 레전더리
+2. **1번 미입력**: 0+100+250=350 ×2 = 700 → 유니크
+3. **2번 일찍 누름**: 100-20+250=330 ×2 = 660 (음수 클램프 적용 확인) → 레어
+4. **모두 0점**: 0 → 일반
+5. **동시 키 입력**: ←↑→ 동시 누르기 → 각 영역 분리 처리 정상
+6. **씬 전환**: result 패널에서 Enter → boss_fight 씬 정상 전환
+
+### 9.3 키 입력 충돌 테스트
+
+- ← 키만 눌렀을 때 1번만 반응 (2·3번 영역 무관)
+- 마스터 타이머 동작 중 Space 누름 → idle/result에서만 처리되므로 영향 없음
+
+---
+
+## 10. 작업 순서
+
+1. **기존 컴포넌트에 `embedded` prop 추가** (3개 병렬 가능)
+   - `TenSecondsGame`: `embedded`, `externalPhase` prop 추가, embedded일 때 자체 패널 숨김 + 자체 종료 비활성화
+   - `ColorReactionGame`: 동일 + 대기 시간 2-6초 단축 (embedded 한정)
+   - `CatchGame`: 동일 + `speedMultiplier` prop 추가 (FALL_DURATION_MS, planSpawnTimes 비례)
+2. **`parallelUtils.js` 작성** — `getParallelGrade(score)` + 등급 메타데이터
+3. **`ParallelGame.jsx` 작성** — 마스터 phase 관리, 점수 수집, 결과 산정, 마스터 타이머
+4. **`ParallelGame.css` 작성** — 3분할 grid, idle/result 패널, HUD
+5. **App.jsx 라우터 교체** — `minigame_4` placeholder → `<ParallelGame />`
+6. **수동 테스트 6개 시나리오 검증**
+7. **유닛 테스트 추가** (`parallelUtils.test.js`) — 기존 테스트 인프라 사용
+
+---
+
+## 11. 영향 받지 않는 영역
+
+- `gameStore`: `ADD_SCORE`, `GO_TO_SCENE`, `SET_WORLD_STAGE` 액션 그대로 사용
+- World scene과 다른 미니게임의 단독 진입 모드 (embedded=false 유지 시 기존 동작)
+- 5단계 등급 시스템 색상/스타일 토큰 (기존 CSS 재사용)
+- PlaceholderScene, IntroScene, EndingScene
+
+---
+
+## 12. 참고
+
+- 이슈 #16: `.issues/20260505_기능추가_미니게임4_병렬_진행_구현.md`
+- 이슈 #12 (선행): scene routing + 5단계 등급 시스템
+- 관련 스펙: `docs/superpowers/specs/2026-05-04-scene-routing-design.md`, `2026-05-04-minigame-stage-expand-design.md`

--- a/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
+++ b/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
@@ -1,0 +1,351 @@
+# 미니게임 4 "결전의 서막" — 병렬 진행 미니게임 설계
+
+- **이슈**: #16 [기능추가][미니게임4] PRD §2.4 병렬 진행 미니게임 구현 (1+2+3번 동시 + 2배 보너스)
+- **컨셉**: 결전의 서막 — *"갑옷을 두른 그린이, 모든 시련을 한 번에"*
+- **위치**: `armor` 씬 직후, `boss_fight` 씬 직전
+- **작성일**: 2026-05-05
+
+---
+
+## 1. 목적과 배경
+
+이슈 #12 작업으로 scene routing은 완성되었으나 4번 미니게임은 placeholder 화면(제목 + "다음으로" 버튼)만 마련된 상태다. 갑옷을 장착한 그린이가 진행해야 할 클라이맥스 단계인데 실제 게임 로직이 없어 스토리상 빈 단계로 남아있다.
+
+PRD §2.4 명세는 1·2·3번을 한 화면에서 동시 진행, 점수 2배, 캐치 속도 1.5배다. 1·2·3번이 "연습/시련"이라면 4번은 갑옷 입은 그린이가 모든 능력(시간 감각·반사신경·동체시력)을 동시에 발휘하는 **결전 직전의 종합 시험**이다.
+
+---
+
+## 2. 요구사항
+
+### 기능 요구사항
+
+- 좌·중·우 3분할 레이아웃에서 1·2·3번 미니게임을 동시 진행
+  - 좌: 10초 맞추기 (← 키)
+  - 중: 색상 반응 (↑ 키)
+  - 우: 캐치 (→ 키, **속도 1.5배**)
+- 게임 시간 10초로 통일된 마스터 타이머
+- 3영역 점수 합산 → **× 2 보너스 적용**
+- 결과 패널에 영역별 점수 + 합산 + 보너스 + 5단계 등급 표시
+- App.jsx 라우터에서 `minigame_4` placeholder를 실제 컴포넌트로 교체
+- onContinue → `boss_fight` 씬 전환
+
+### 비기능 요구사항
+
+- 1·2·3번 게임 컴포넌트의 게임 로직(점수/판정) 재사용 (코드 중복 금지)
+- 5단계 등급 시스템 (레전더리/유니크/에픽/레어/일반) 그대로 사용
+- Stage 1920×960 base + transform scale fit (다른 미니게임과 일관)
+- gameStore.scene 기반 라우팅 패턴 유지 (외부 라우터 도입 금지)
+
+### 비범위 (Out of Scope)
+
+- 갑옷/검 스프라이트(`walk_weapon`) 시각 적용 — 별도 갑옷 이슈에서 처리되면 자연 연동
+- 보스전 데미지 산출 로직 — 본 이슈는 점수 합산까지만 담당
+- 1·2·3번 단독 진입 미니게임의 동작 변경 — embedded 모드 추가만, 기존 동작 유지
+
+---
+
+## 3. 아키텍처
+
+### 3.1 새 컴포넌트
+
+```
+src/components/ParallelGame/
+├── ParallelGame.jsx          # 마스터 오케스트레이터 (idle/running/result)
+├── ParallelGame.css          # 3분할 레이아웃 + 결과 패널
+└── parallelUtils.js          # getParallelGrade(totalBonus) + 등급 메타
+```
+
+### 3.2 기존 컴포넌트 확장 — `embedded` 모드
+
+`TenSecondsGame`, `ColorReactionGame`, `CatchGame`에 다음 prop을 추가한다:
+
+| Prop | Type | 기본값 | 설명 |
+|---|---|---|---|
+| `embedded` | boolean | `false` | true일 때 자체 idle/result 패널을 숨기고 자체 종료 타이머 비활성화 |
+| `externalPhase` | `'idle' \| 'running' \| 'result'` | undefined | embedded일 때 외부에서 phase 주입 (마스터 타이머가 통제) |
+| `speedMultiplier` (CatchGame 전용) | number | `1` | FALL_DURATION_MS와 planSpawnTimes 결과를 분할해 낙하 속도 가속 |
+
+**embedded 모드 동작**:
+- 자체 idle/result 패널 렌더링 생략 (running phase의 게임 stage UI만 렌더)
+- `externalPhase === 'running'`이 들어오면 자동 시작 (mount 직후 또는 phase 변화 시점)
+- 자체 종료 트리거 비활성화 — 게임 종료는 오직 `externalPhase === 'result'` 수신으로만 발생:
+  - `TenSecondsGame`: 자체 종료 트리거는 ← 키 한정. 마스터가 'result' 전파하면 그 시점의 finalTime/score를 확정 (← 안 눌렀으면 score=0)
+  - `ColorReactionGame`: 자체 10초 카운트다운(`gameIntervalRef`) 비활성화. 마스터 'result' 시점에 cleanup
+  - `CatchGame`: `endTimeoutRef` 비활성화. 마스터 'result' 시점에 cleanup. `cleanupTimeoutsRef` (아이템 자동 제거 timeout)는 유지 — 시각 정리용
+- `externalPhase === 'result'` 수신 시 컴포넌트는 자체 cleanup 함수를 호출하고 미보고 score를 확정 (1회 한정 onComplete)
+- 자체 keydown listener는 그대로 유지 (←/↑/→ 키가 다르므로 충돌 없음, Enter/Space는 embedded일 때 무시)
+- `onComplete(score)`은 기존대로 1회 호출 (`completedRef` 가드)
+
+### 3.3 데이터 흐름
+
+```
+ParallelGame (마스터)
+├─ phase: 'idle' → Space/Enter → 'running' → 10초 후 'result'
+├─ scoreLeft / scoreCenter / scoreRight (각 영역 onComplete로 수집)
+├─ totalRaw = clamp(L+C+R, ≥0)
+├─ totalBonus = totalRaw × 2
+├─ grade = getParallelGrade(totalBonus)
+└─ Renders:
+   ├─ Phase 'idle': 통합 안내 패널
+   ├─ Phase 'running': 3분할 grid
+   │   ├─ Left:   <TenSecondsGame embedded externalPhase="running" onComplete={setScoreLeft} />
+   │   ├─ Center: <ColorReactionGame embedded externalPhase="running" onComplete={setScoreCenter} />
+   │   └─ Right:  <CatchGame embedded externalPhase="running" speedMultiplier={1.5} onComplete={setScoreRight} />
+   └─ Phase 'result': 통합 결과 패널
+```
+
+### 3.4 라우터 연결
+
+```jsx
+// App.jsx
+{state.scene === 'minigame_4' && (
+  <ParallelGame
+    onComplete={(score) => dispatch({ type: 'ADD_SCORE', payload: score })}
+    onContinue={() => {
+      dispatch({ type: 'SET_WORLD_STAGE', payload: 5 });
+      dispatch({ type: 'GO_TO_SCENE', payload: 'boss_fight' });
+    }}
+  />
+)}
+```
+
+---
+
+## 4. 타이밍과 키보드
+
+### 4.1 마스터 타이머
+
+- `ParallelGame`은 phase 'running' 진입 시점에 `startMs = performance.now()` 기록
+- `requestAnimationFrame` 루프로 `elapsedMs` 갱신 → 상단 HUD에 "남은 시간 X.Xs" 표시
+- `elapsedMs >= 10000`이 되면 phase 'result'로 전환
+- 각 영역의 자체 종료는 `externalPhase="result"` 전파로만 트리거됨 (자체 endTimeout 비활성화)
+
+### 4.2 키보드 입력 분리
+
+- 각 게임 컴포넌트의 기존 `window keydown` listener 그대로 유지
+- ←, ↑, → 키 코드가 달라 자연스럽게 분리됨 (동시 입력 시 각 영역 독립 처리)
+- `ParallelGame`은 별도 listener:
+  - Phase 'idle' + Space/Enter → phase 'running'으로 전환
+  - Phase 'result' + Space/Enter → `onContinue()` 호출
+
+### 4.3 진입 키 잔류 방지
+
+- 4번 씬 진입은 World에서 발생하므로 idle 패널 시작 키(Space/Enter)는 잔류 위험 없음
+- 기존 `CatchGame`의 `rightKeyArmedRef` 패턴은 그대로 유지 (혹시 모를 케이스 대비)
+
+---
+
+## 5. 게임별 동작 디테일
+
+### 5.1 1번 — 10초 맞추기 (좌)
+
+- mount + `externalPhase="running"` → `startGame()` 자동 호출
+- ← 키 누르면 finalTime 기록 → `onComplete(getScore(diff))` 즉시 호출
+- 사용자가 ← 안 누르고 마스터 10초 끝남 → `onComplete` 미호출 → ParallelGame이 phase 'result' 시점에 `scoreLeft = 0` 적용
+- 영역 안에서는 타이머 디지트와 elapsed time만 표시
+
+### 5.2 2번 — 색상 반응 (중)
+
+- mount + `externalPhase="running"` → `startGame()` 호출
+- ⚠️ 기존 대기 시간 4-10초는 마스터 10초 안에 react 윈도우가 안 생길 수 있음
+  - **embedded 모드 한정**: 대기 시간을 **2-6초 랜덤**으로 단축 (반응 윈도우 4-8초 보장)
+- 일찍 ↑ 누름 → `-20점`
+- 시간 초과 → `0점`
+- 정상 react → `getScore(reactionTime)` (100/80/60/40/20)
+
+### 5.3 3번 — 캐치 (우)
+
+- mount + `externalPhase="running"` + `speedMultiplier=1.5` → `startGame()` 호출
+- `FALL_DURATION_MS_EFFECTIVE = FALL_DURATION_MS / 1.5` (낙하 가속)
+- `planSpawnTimes(...)` 호출 시 `fallMs` 인자에 effective 값을 전달해 6개 spawn이 10초 내에 빨간 원 도달하도록 보장 (랜덤 gap에 따라 실제 5~6개 spawn)
+- `FallingItem`에 `speedMultiplier` prop을 그대로 전달 (기존 컴포넌트가 이미 `animationDuration` 분할 지원)
+- → 키 입력의 거리 판정은 `FALL_DURATION_MS_EFFECTIVE`로 계산해야 정확
+
+---
+
+## 6. 점수와 등급
+
+### 6.1 점수 합산
+
+- 영역별 score는 `ParallelGame`의 로컬 state로 누적
+- Phase 'result' 진입 시점에:
+  - 미보고 영역(예: 1번 ← 안 누름)은 `0` 강제 적용
+  - `totalRaw = Math.max(0, scoreLeft + scoreCenter + scoreRight)` (음수 클램프)
+  - `totalBonus = totalRaw × 2`
+  - `onComplete(totalBonus)` 호출 → gameStore에 가산
+  - `getParallelGrade(totalBonus)`로 등급 산정
+
+### 6.2 5단계 등급 임계치
+
+각 영역 max 점수: 1번 100 + 2번 100 + 3번 300 (`SPAWN_COUNT=6` × 50) = **합산 max 500** → **× 2 보너스 max 1000**
+
+| 등급 | 색상 | 별 | 임계치 (max 1000) | % |
+|---|---|---|---|---|
+| 🌟 레전더리 | `#ffd700` (gold) | ⭐⭐⭐⭐⭐ | ≥ 900 | ≥ 90% |
+| 💎 유니크 | `#ff007f` (pink) | ⭐⭐⭐⭐ | ≥ 750 | ≥ 75% |
+| 🔮 에픽 | `#a78bfa` (purple) | ⭐⭐⭐ | ≥ 550 | ≥ 55% |
+| ⚔️ 레어 | `#60a5fa` (blue) | ⭐⭐ | ≥ 300 | ≥ 30% |
+| 🛡️ 일반 | `#86efac` (green) | ⭐ | < 300 | < 30% |
+
+> 색상 토큰은 다른 미니게임의 `tier-*` 클래스와 통일 (gameUtils/reactionUtils/catchUtils의 `getResult` 색상과 일치).
+
+### 6.3 `parallelUtils.js` 시그니처
+
+```js
+export const PARALLEL_MAX_SCORE = 1000;
+export const PARALLEL_GRADES = [
+  { grade: 'LEGENDARY', threshold: 900, stars: 5, color: '#ffd700', title: '🌟 결전의 영웅', desc: '갑옷 입은 그린이의 모든 능력이 폭발했다.' },
+  { grade: 'UNIQUE',    threshold: 750, stars: 4, color: '#ff007f', title: '💎 갑옷의 수호자', desc: '훌륭한 종합 시험. 보스 앞에서도 흔들리지 않으리라.' },
+  { grade: 'EPIC',      threshold: 550, stars: 3, color: '#a78bfa', title: '🔮 결전의 전사', desc: '준비는 충분하다. 보스를 향해 나아가자.' },
+  { grade: 'RARE',      threshold: 300, stars: 2, color: '#60a5fa', title: '⚔️ 시련의 통과자', desc: '아슬아슬하게 시련을 통과했다.' },
+  { grade: 'COMMON',    threshold: 0,   stars: 1, color: '#86efac', title: '🛡️ 새내기 전사', desc: '아직 부족하지만 보스를 향한 첫 발은 뗐다.' },
+];
+
+export function getParallelGrade(totalBonus) {
+  const score = Math.max(0, totalBonus);
+  return PARALLEL_GRADES.find(g => score >= g.threshold);
+}
+```
+
+---
+
+## 7. UI 레이아웃
+
+### 7.1 Stage (1920×960 base)
+
+```
+┌─────────────────────────────────────────────────┐
+│  [상단 HUD: 결전의 서막  |  남은 시간 7.3s]     │  ← 80px
+├──────────────┬──────────────┬───────────────────┤
+│              │              │                   │
+│   [1번]      │   [2번]      │     [3번]         │
+│  10초맞추기  │  색상반응     │     캐치          │  ← 880px
+│   (←)        │   (↑)        │     (→ × 1.5x)   │
+│              │              │                   │
+└──────────────┴──────────────┴───────────────────┘
+   width: 33.3%   33.3%          33.3%
+```
+
+- CSS Grid 3-column (`grid-template-columns: 1fr 1fr 1fr`)
+- 각 영역의 game stage는 transform scale로 자기 영역에 맞게 축소 (overflow hidden)
+- 상단 HUD는 `position: absolute; top: 0;`로 영역 위에 띄움
+
+### 7.2 Idle 패널
+
+- 전체 화면 단일 패널, 어두운 배경 위에 카드
+- 제목: **"⚔️ 결전의 서막"**
+- 부제: *"갑옷을 두른 그린이, 모든 시련을 한 번에"*
+- 3개 영역 게임 미니카드 (좌·중·우):
+  - 좌: ⏱ 10초 맞추기 / ← 키
+  - 중: 🗿 침묵의 석상 / ↑ 키
+  - 우: ⚔️ 장비 캐치 / → 키 (속도 1.5×)
+- 보너스 안내: **"3영역 합산 점수 × 2배 보너스"**
+- 등급표 (5단계, max 900 기준) — 기존 `.score-rules` + `tier-*` 클래스 재사용
+- 시작 버튼: "▶ 결전 시작 (Space / Enter)"
+
+### 7.3 Result 패널
+
+```
+   [등급 배지: 레전더리 🌟]
+   "결전의 영웅"
+   ⭐⭐⭐⭐⭐
+
+   ┌─────────────────────────┐
+   │ 좌 (10초 맞추기)   +80  │
+   │ 중 (색상 반응)     +60  │
+   │ 우 (캐치)         +220  │
+   ├─────────────────────────┤
+   │ 합산              +360  │
+   │ × 2 보너스        +720  │
+   ├─────────────────────────┤
+   │ 최종 점수         +720  │  ← highlight
+   └─────────────────────────┘
+
+   [다음으로 (Enter / Space)]
+```
+
+- 기존 미니게임 result 패널 스타일 재사용 (`.result-panel`, `tier-*` 색상 토큰)
+- `StarRating` 컴포넌트 재사용 (`TenSecondsGame/StarRating.jsx`)
+
+---
+
+## 8. 에러 / 엣지 케이스
+
+| 케이스 | 처리 |
+|---|---|
+| 1번 ← 안 누름 | scoreLeft 미보고 → 'result' 시점에 `0` 적용 |
+| 2번 일찍 ↑ 누름 | 기존 로직: `-20`점. `totalRaw` 합산 시 `Math.max(0, ...)`로 클램프 |
+| 2번 시간 초과 | 0점. embedded 대기 2-6초 단축으로 react 윈도우 보장 |
+| 3번 캐치 일부 놓침 | 기존 로직: 놓친 아이템 0점 |
+| onComplete 중복 호출 | 각 컴포넌트의 `completedRef` 가드로 1회만 호출 (기존 패턴 유지) |
+| 마스터 타이머 vs 자체 종료 충돌 | embedded 모드에서 자체 endTimeout/timer 비활성화. 종료는 `externalPhase`로만 트리거 |
+| 진입 키 잔류 | idle → Space/Enter 시작이라 ←/↑/→ 잔류 무관. CatchGame `rightKeyArmedRef` 패턴 유지 |
+| 점수 음수 (2번 -20) | `Math.max(0, totalBonus)`로 클램프 후 등급 산정 |
+
+---
+
+## 9. 테스트 전략
+
+### 9.1 등급 함수 검증 (인라인 console.assert)
+
+테스트 인프라(vitest/jest)가 미도입 상태이므로 별도 인프라 도입 없이 `parallelUtils.js` 하단에 자체 self-test를 두거나, 개발 콘솔에서 다음 임계치를 수동 검증:
+
+- `getParallelGrade(1000).grade === 'LEGENDARY'`
+- `getParallelGrade(900).grade === 'LEGENDARY'`
+- `getParallelGrade(899).grade === 'UNIQUE'`
+- `getParallelGrade(750).grade === 'UNIQUE'`
+- `getParallelGrade(549).grade === 'RARE'`
+- `getParallelGrade(300).grade === 'RARE'`
+- `getParallelGrade(299).grade === 'COMMON'`
+- `getParallelGrade(0).grade === 'COMMON'`
+- `getParallelGrade(-100).grade === 'COMMON'` (음수 클램프)
+
+> 후속 이슈로 vitest 인프라 도입 시 정식 단위 테스트로 이관.
+
+### 9.2 수동 / 통합 테스트 (브라우저)
+
+Vite dev 서버에서 `state.scene = 'minigame_4'` 진입 후 6개 시나리오:
+
+1. **만점 근접**: 모든 영역 최고 등급 → 합산 ≈ 500 ×2 = 1000 → 레전더리
+2. **1번 미입력**: 0+100+300=400 ×2 = 800 → 유니크
+3. **2번 일찍 누름**: 100-20+300=380 ×2 = 760 (음수 클램프 적용 확인) → 유니크
+4. **모두 0점**: 0 → 일반
+5. **동시 키 입력**: ←↑→ 동시 누르기 → 각 영역 분리 처리 정상
+6. **씬 전환**: result 패널에서 Enter → boss_fight 씬 정상 전환
+
+### 9.3 키 입력 충돌 테스트
+
+- ← 키만 눌렀을 때 1번만 반응 (2·3번 영역 무관)
+- 마스터 타이머 동작 중 Space 누름 → idle/result에서만 처리되므로 영향 없음
+
+---
+
+## 10. 작업 순서
+
+1. **기존 컴포넌트에 `embedded` prop 추가** (3개 병렬 가능)
+   - `TenSecondsGame`: `embedded`, `externalPhase` prop 추가, embedded일 때 자체 패널 숨김 + 자체 종료 비활성화
+   - `ColorReactionGame`: 동일 + 대기 시간 2-6초 단축 (embedded 한정)
+   - `CatchGame`: 동일 + `speedMultiplier` prop 추가 (FALL_DURATION_MS, planSpawnTimes 비례)
+2. **`parallelUtils.js` 작성** — `getParallelGrade(score)` + 등급 메타데이터
+3. **`ParallelGame.jsx` 작성** — 마스터 phase 관리, 점수 수집, 결과 산정, 마스터 타이머
+4. **`ParallelGame.css` 작성** — 3분할 grid, idle/result 패널, HUD
+5. **App.jsx 라우터 교체** — `minigame_4` placeholder → `<ParallelGame />`
+6. **수동 테스트 6개 시나리오 검증**
+7. **유닛 테스트 추가** (`parallelUtils.test.js`) — 기존 테스트 인프라 사용
+
+---
+
+## 11. 영향 받지 않는 영역
+
+- `gameStore`: `ADD_SCORE`, `GO_TO_SCENE`, `SET_WORLD_STAGE` 액션 그대로 사용
+- World scene과 다른 미니게임의 단독 진입 모드 (embedded=false 유지 시 기존 동작)
+- 5단계 등급 시스템 색상/스타일 토큰 (기존 CSS 재사용)
+- PlaceholderScene, IntroScene, EndingScene
+
+---
+
+## 12. 참고
+
+- 이슈 #16: `.issues/20260505_기능추가_미니게임4_병렬_진행_구현.md`
+- 이슈 #12 (선행): scene routing + 5단계 등급 시스템
+- 관련 스펙: `docs/superpowers/specs/2026-05-04-scene-routing-design.md`, `2026-05-04-minigame-stage-expand-design.md`

--- a/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
+++ b/docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md
@@ -157,8 +157,9 @@ ParallelGame (마스터)
 
 - mount + `externalPhase="running"` + `speedMultiplier=1.5` → `startGame()` 호출
 - `FALL_DURATION_MS_EFFECTIVE = FALL_DURATION_MS / 1.5` (낙하 가속)
-- `planSpawnTimes()` 결과도 동일 비율로 단축 → 10초 내 5개 등장 유지
-- → 키 처리 그대로
+- `planSpawnTimes(...)` 호출 시 `fallMs` 인자에 effective 값을 전달해 6개 spawn이 10초 내에 빨간 원 도달하도록 보장 (랜덤 gap에 따라 실제 5~6개 spawn)
+- `FallingItem`에 `speedMultiplier` prop을 그대로 전달 (기존 컴포넌트가 이미 `animationDuration` 분할 지원)
+- → 키 입력의 거리 판정은 `FALL_DURATION_MS_EFFECTIVE`로 계산해야 정확
 
 ---
 
@@ -176,26 +177,28 @@ ParallelGame (마스터)
 
 ### 6.2 5단계 등급 임계치
 
-각 영역 max 점수: 1번 100 + 2번 100 + 3번 250 = **합산 max 450** → **× 2 보너스 max 900**
+각 영역 max 점수: 1번 100 + 2번 100 + 3번 300 (`SPAWN_COUNT=6` × 50) = **합산 max 500** → **× 2 보너스 max 1000**
 
-| 등급 | 색상 | 별 | 임계치 (max 900) | % |
+| 등급 | 색상 | 별 | 임계치 (max 1000) | % |
 |---|---|---|---|---|
-| 🌟 레전더리 | `#fbbf24` (gold) | ⭐⭐⭐⭐⭐ | ≥ 810 | ≥ 90% |
-| 💎 유니크 | `#a78bfa` (purple) | ⭐⭐⭐⭐ | ≥ 675 | ≥ 75% |
-| 🔮 에픽 | `#60a5fa` (blue) | ⭐⭐⭐ | ≥ 495 | ≥ 55% |
-| ⚔️ 레어 | `#34d399` (green) | ⭐⭐ | ≥ 270 | ≥ 30% |
-| 🛡️ 일반 | `#9ca3af` (gray) | ⭐ | < 270 | < 30% |
+| 🌟 레전더리 | `#ffd700` (gold) | ⭐⭐⭐⭐⭐ | ≥ 900 | ≥ 90% |
+| 💎 유니크 | `#ff007f` (pink) | ⭐⭐⭐⭐ | ≥ 750 | ≥ 75% |
+| 🔮 에픽 | `#a78bfa` (purple) | ⭐⭐⭐ | ≥ 550 | ≥ 55% |
+| ⚔️ 레어 | `#60a5fa` (blue) | ⭐⭐ | ≥ 300 | ≥ 30% |
+| 🛡️ 일반 | `#86efac` (green) | ⭐ | < 300 | < 30% |
+
+> 색상 토큰은 다른 미니게임의 `tier-*` 클래스와 통일 (gameUtils/reactionUtils/catchUtils의 `getResult` 색상과 일치).
 
 ### 6.3 `parallelUtils.js` 시그니처
 
 ```js
-export const PARALLEL_MAX_SCORE = 900;
+export const PARALLEL_MAX_SCORE = 1000;
 export const PARALLEL_GRADES = [
-  { grade: '레전더리', threshold: 810, stars: 5, color: '#fbbf24', title: '🌟 결전의 영웅' },
-  { grade: '유니크',   threshold: 675, stars: 4, color: '#a78bfa', title: '💎 갑옷의 수호자' },
-  { grade: '에픽',     threshold: 495, stars: 3, color: '#60a5fa', title: '🔮 결전의 전사' },
-  { grade: '레어',     threshold: 270, stars: 2, color: '#34d399', title: '⚔️ 시련의 통과자' },
-  { grade: '일반',     threshold: 0,   stars: 1, color: '#9ca3af', title: '🛡️ 새내기 전사' },
+  { grade: 'LEGENDARY', threshold: 900, stars: 5, color: '#ffd700', title: '🌟 결전의 영웅', desc: '갑옷 입은 그린이의 모든 능력이 폭발했다.' },
+  { grade: 'UNIQUE',    threshold: 750, stars: 4, color: '#ff007f', title: '💎 갑옷의 수호자', desc: '훌륭한 종합 시험. 보스 앞에서도 흔들리지 않으리라.' },
+  { grade: 'EPIC',      threshold: 550, stars: 3, color: '#a78bfa', title: '🔮 결전의 전사', desc: '준비는 충분하다. 보스를 향해 나아가자.' },
+  { grade: 'RARE',      threshold: 300, stars: 2, color: '#60a5fa', title: '⚔️ 시련의 통과자', desc: '아슬아슬하게 시련을 통과했다.' },
+  { grade: 'COMMON',    threshold: 0,   stars: 1, color: '#86efac', title: '🛡️ 새내기 전사', desc: '아직 부족하지만 보스를 향한 첫 발은 뗐다.' },
 ];
 
 export function getParallelGrade(totalBonus) {
@@ -250,12 +253,12 @@ export function getParallelGrade(totalBonus) {
    ┌─────────────────────────┐
    │ 좌 (10초 맞추기)   +80  │
    │ 중 (색상 반응)     +60  │
-   │ 우 (캐치)         +180  │
+   │ 우 (캐치)         +220  │
    ├─────────────────────────┤
-   │ 합산              +320  │
-   │ × 2 보너스        +640  │
+   │ 합산              +360  │
+   │ × 2 보너스        +720  │
    ├─────────────────────────┤
-   │ 최종 점수         +640  │  ← highlight
+   │ 최종 점수         +720  │  ← highlight
    └─────────────────────────┘
 
    [다음으로 (Enter / Space)]
@@ -283,18 +286,29 @@ export function getParallelGrade(totalBonus) {
 
 ## 9. 테스트 전략
 
-### 9.1 유닛 테스트 (`parallelUtils.test.js`)
+### 9.1 등급 함수 검증 (인라인 console.assert)
 
-- `getParallelGrade(score)` 임계치 경계: 810, 809, 675, 495, 270, 269, 0, 음수
-- 각 등급별 색상/타이틀/별 개수 매핑 검증
+테스트 인프라(vitest/jest)가 미도입 상태이므로 별도 인프라 도입 없이 `parallelUtils.js` 하단에 자체 self-test를 두거나, 개발 콘솔에서 다음 임계치를 수동 검증:
+
+- `getParallelGrade(1000).grade === 'LEGENDARY'`
+- `getParallelGrade(900).grade === 'LEGENDARY'`
+- `getParallelGrade(899).grade === 'UNIQUE'`
+- `getParallelGrade(750).grade === 'UNIQUE'`
+- `getParallelGrade(549).grade === 'RARE'`
+- `getParallelGrade(300).grade === 'RARE'`
+- `getParallelGrade(299).grade === 'COMMON'`
+- `getParallelGrade(0).grade === 'COMMON'`
+- `getParallelGrade(-100).grade === 'COMMON'` (음수 클램프)
+
+> 후속 이슈로 vitest 인프라 도입 시 정식 단위 테스트로 이관.
 
 ### 9.2 수동 / 통합 테스트 (브라우저)
 
 Vite dev 서버에서 `state.scene = 'minigame_4'` 진입 후 6개 시나리오:
 
-1. **만점**: 모든 영역 만점 → 합산 450 ×2 = 900 → 레전더리
-2. **1번 미입력**: 0+100+250=350 ×2 = 700 → 유니크
-3. **2번 일찍 누름**: 100-20+250=330 ×2 = 660 (음수 클램프 적용 확인) → 레어
+1. **만점 근접**: 모든 영역 최고 등급 → 합산 ≈ 500 ×2 = 1000 → 레전더리
+2. **1번 미입력**: 0+100+300=400 ×2 = 800 → 유니크
+3. **2번 일찍 누름**: 100-20+300=380 ×2 = 760 (음수 클램프 적용 확인) → 유니크
 4. **모두 0점**: 0 → 일반
 5. **동시 키 입력**: ←↑→ 동시 누르기 → 각 영역 분리 처리 정상
 6. **씬 전환**: result 패널에서 Enter → boss_fight 씬 정상 전환

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import EndingScene from './scenes/EndingScene.jsx';
 import TenSecondsGame from './components/TenSecondsGame/TenSecondsGame';
 import ColorReactionGame from './components/ColorReactionGame/ColorReactionGame';
 import CatchGame from './components/CatchGame/CatchGame';
+import ParallelGame from './components/ParallelGame/ParallelGame';
 import './App.css';
 
 export default function App() {
@@ -58,11 +59,13 @@ export default function App() {
           }} />
       )}
       {state.scene === 'minigame_4' && (
-        <PlaceholderScene title="⚔️ 미니게임 4: 병렬 진행" description="(별도 이슈에서 구현 예정)"
+        <ParallelGame
+          onComplete={(score) => dispatch({ type: 'ADD_SCORE', payload: score })}
           onContinue={() => {
             dispatch({ type: 'SET_WORLD_STAGE', payload: 5 });
-            dispatch({ type: 'GO_TO_SCENE', payload: 'world' });
-          }} />
+            dispatch({ type: 'GO_TO_SCENE', payload: 'boss_fight' });
+          }}
+        />
       )}
       {state.scene === 'boss_fight' && (
         <PlaceholderScene title="🔥 보스전" description="(별도 이슈에서 구현 예정)"

--- a/src/components/CatchGame/CatchGame.jsx
+++ b/src/components/CatchGame/CatchGame.jsx
@@ -6,25 +6,40 @@ import {
   RED_CIRCLE_TOP_RATIO,
   HIT_RANGE_MAX,
   ITEM_VISUAL_HEIGHT_PX,
+  FAIL_PENALTY,
+  SPAWN_COUNT,
   planSpawnTimes,
   pickRandomType,
   judgeHit,
   getItemY,
   getCatchResult,
 } from './catchUtils';
+
+const MAX_INPUTS = SPAWN_COUNT;
 import FallingItem from './FallingItem';
 import StarRating from '../TenSecondsGame/StarRating';
 import './CatchGame.css';
 
 let nextItemId = 1;
 
-export default function CatchGame({ autoStart = false, onComplete, onContinue }) {
+export default function CatchGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  speedMultiplier = 1,
+  onComplete,
+  onContinue,
+}) {
   const [phase, setPhase] = useState('idle');
   const [activeItems, setActiveItems] = useState([]);
   const [elapsedMs, setElapsedMs] = useState(0);
   const [score, setScore] = useState(0);
   const [counts, setCounts] = useState({ perfect: 0, near: 0, fail: 0, miss: 0 });
   const [feedback, setFeedback] = useState(null);
+  const [inputCount, setInputCount] = useState(0);
+  const inputCountRef = useRef(0);
+
+  const fallDurationMsEffective = FALL_DURATION_MS / speedMultiplier;
 
   const gameStartMsRef = useRef(0);
   const spawnTimeoutsRef = useRef([]);
@@ -81,9 +96,9 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
         }
         return prev.filter((it) => it.id !== id);
       });
-    }, FALL_DURATION_MS + 300);
+    }, fallDurationMsEffective + 300);
     cleanupTimeoutsRef.current.push(tid);
-  }, [showFeedback]);
+  }, [showFeedback, fallDurationMsEffective]);
 
   const cleanupTimers = useCallback(() => {
     spawnTimeoutsRef.current.forEach(clearTimeout);
@@ -106,26 +121,37 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
     scoreRef.current = 0;
     setCounts({ perfect: 0, near: 0, fail: 0, miss: 0 });
     setFeedback(null);
+    setInputCount(0);
+    inputCountRef.current = 0;
     completedRef.current = false;
     gameStartMsRef.current = performance.now();
     setPhase('running');
 
-    const schedule = planSpawnTimes();
+    const schedule = planSpawnTimes(
+      GAME_DURATION_MS,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      fallDurationMsEffective,
+    );
     spawnTimeoutsRef.current = schedule.map((t) => setTimeout(spawnItem, t));
 
     tickIntervalRef.current = setInterval(() => {
       setElapsedMs(performance.now() - gameStartMsRef.current);
     }, 100);
 
-    endTimeoutRef.current = setTimeout(() => {
-      cleanupTimers();
-      setPhase('result');
-      if (!completedRef.current) {
-        completedRef.current = true;
-        onComplete?.(scoreRef.current);
-      }
-    }, GAME_DURATION_MS);
-  }, [cleanupTimers, spawnItem, onComplete]);
+    if (!embedded) {
+      endTimeoutRef.current = setTimeout(() => {
+        cleanupTimers();
+        setPhase('result');
+        if (!completedRef.current) {
+          completedRef.current = true;
+          onComplete?.(scoreRef.current);
+        }
+      }, GAME_DURATION_MS);
+    }
+  }, [cleanupTimers, spawnItem, onComplete, embedded, fallDurationMsEffective]);
 
   // 키보드: → 캐치, Space 시작(autoStart=false), Enter 다음으로
   useEffect(() => {
@@ -149,24 +175,40 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
           const elapsed = nowSinceStart - it.spawnAt;
           if (elapsed < 0) continue;
           // getItemY는 이모지 div의 top edge → 시각 center로 보정
-          const itemCenterY = getItemY(elapsed, STAGE_HEIGHT_PX, FALL_DURATION_MS) + ITEM_VISUAL_HEIGHT_PX / 2;
+          const itemCenterY = getItemY(elapsed, STAGE_HEIGHT_PX, fallDurationMsEffective) + ITEM_VISUAL_HEIGHT_PX / 2;
           const dist = Math.abs(itemCenterY - circleCenterY);
           if (dist < bestDist) { bestDist = dist; bestId = it.id; }
         }
         if (bestId === null) return;
+
+        // 한 번의 의미 있는 → 입력 = 기회 1회 차감
+        inputCountRef.current += 1;
+        setInputCount(inputCountRef.current);
+
         if (bestDist > HIT_RANGE_MAX) {
+          setScore((s) => s + FAIL_PENALTY);
           setCounts((c) => ({ ...c, fail: c.fail + 1 }));
-          showFeedback('fail', 'FAIL');
-          return;
+          showFeedback('fail', `FAIL ${FAIL_PENALTY}`);
+        } else {
+          const result = judgeHit(bestDist);
+          setScore((s) => s + result.score);
+          setCounts((c) => ({ ...c, [result.kind]: c[result.kind] + 1 }));
+          const label = result.kind === 'perfect' ? 'PERFECT +50'
+                      : result.kind === 'near'    ? 'GOOD +20'
+                      :                              `FAIL ${FAIL_PENALTY}`;
+          showFeedback(result.kind, label);
+          removeItem(bestId);
         }
-        const result = judgeHit(bestDist);
-        setScore((s) => s + result.score);
-        setCounts((c) => ({ ...c, [result.kind]: c[result.kind] + 1 }));
-        const label = result.kind === 'perfect' ? 'PERFECT +50'
-                    : result.kind === 'near'    ? 'GOOD +20'
-                    :                              'FAIL';
-        showFeedback(result.kind, label);
-        removeItem(bestId);
+
+        // 기회 5번 모두 소진 → 즉시 종료
+        if (inputCountRef.current >= MAX_INPUTS) {
+          cleanupTimers();
+          setPhase('result');
+          if (!completedRef.current) {
+            completedRef.current = true;
+            onComplete?.(scoreRef.current);
+          }
+        }
       } else if ((e.code === 'Enter' || e.code === 'Space')
                  && phaseRef.current === 'result'
                  && onContinue) {
@@ -176,7 +218,7 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [removeItem, startGame, showFeedback, autoStart, onContinue]);
+  }, [removeItem, startGame, showFeedback, autoStart, onContinue, cleanupTimers, onComplete]);
 
   useEffect(() => () => cleanupTimers(), [cleanupTimers]);
 
@@ -187,6 +229,19 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoStart]);
+
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 누적 점수로 보고
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phaseRef.current === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      cleanupTimers();
+      setPhase('result');
+      completedRef.current = true;
+      onComplete?.(scoreRef.current);
+    }
+  }, [embedded, externalPhase, startGame, cleanupTimers, onComplete]);
 
   const remainingSec = Math.max(0, (GAME_DURATION_MS - elapsedMs) / 1000);
 
@@ -202,7 +257,7 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
       </div>
 
       {phase === 'running' && activeItems.map((item) => (
-        <FallingItem key={item.id} type={item.type} />
+        <FallingItem key={item.id} type={item.type} speedMultiplier={speedMultiplier} />
       ))}
 
       {phase === 'running' && feedback && (
@@ -216,17 +271,18 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
       )}
 
       <div className="catch-ui-overlay">
-        {phase === 'idle' && !autoStart && (
+        {!embedded && phase === 'idle' && !autoStart && (
           <div className="catch-panel catch-panel-start">
             <h2 className="catch-title">⚔️ 장비 드롭의 시련</h2>
             <p className="catch-subtitle">"흐름을 읽고 잡아내라!"</p>
             <p>신이 내려주는 장비를 제단(빨간 원) 위치에서 <b>→ 키</b>로 잡아라!</p>
-            <p className="catch-hint">검 ⚔️ · 방패 🛡️ · 포션 🧪 (10초 동안 5개 등장)</p>
+            <p className="catch-hint">검 ⚔️ · 방패 🛡️ · 포션 🧪 · 10초 / 기회 5번</p>
             <div className="score-rules">
               <div className="score-rules-title">📊 판정 기준 (1회 캐치당)</div>
               <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ PERFECT (정중앙)</span><b>+50점</b></div>
               <div className="score-rule tier-rare"><span>⭐⭐ NEAR (근접)</span><b>+20점</b></div>
-              <div className="score-rule score-rule-bad"><span>FAIL / MISS</span><b>0점</b></div>
+              <div className="score-rule score-rule-bad"><span>FAIL (잘못 누름)</span><b>{FAIL_PENALTY}점</b></div>
+              <div className="score-rule score-rule-bad"><span>MISS (놓침)</span><b>0점</b></div>
               <div className="score-rules-title" style={{ marginTop: 8 }}>🏆 누적 등급 (5개 만점 250)</div>
               <div className="score-rule tier-legendary"><span>⭐⭐⭐⭐⭐ 레전더리</span><b>≥230점</b></div>
               <div className="score-rule tier-unique"><span>⭐⭐⭐⭐ 유니크</span><b>≥180점</b></div>
@@ -243,18 +299,23 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
         {phase === 'running' && (
           <>
             <div className="catch-hud">
-              <div className="catch-hud-row">
-                <span>남은 시간</span><b>{remainingSec.toFixed(1)}s</b>
-              </div>
+              {!embedded && (
+                <div className="catch-hud-row">
+                  <span>남은 시간</span><b>{remainingSec.toFixed(1)}s</b>
+                </div>
+              )}
               <div className="catch-hud-row">
                 <span>점수</span><b>{score}</b>
               </div>
+              <div className="catch-hud-row">
+                <span>기회</span><b>{Math.max(0, MAX_INPUTS - inputCount)} / {MAX_INPUTS}</b>
+              </div>
             </div>
-            <div className="catch-running-hint">→ 키로 거치대에서 잡아라!</div>
+            {!embedded && <div className="catch-running-hint">→ 키로 거치대에서 잡아라!</div>}
           </>
         )}
 
-        {phase === 'result' && (() => {
+        {!embedded && phase === 'result' && (() => {
           const result = getCatchResult(score);
           const totalJudged = counts.perfect + counts.near + counts.fail + counts.miss;
           return (
@@ -267,10 +328,11 @@ export default function CatchGame({ autoStart = false, onComplete, onContinue })
               <StarRating count={result.stars} />
 
               <div className="catch-stats">
-                <div className="catch-stat-row"><span>총점</span><span className="catch-stat-value">+{score}</span></div>
-                <div className="catch-stat-row"><span>완벽 (50점)</span><span>{counts.perfect}</span></div>
-                <div className="catch-stat-row"><span>근접 (20점)</span><span>{counts.near}</span></div>
-                <div className="catch-stat-row"><span>실패 / 놓침</span><span>{counts.fail + counts.miss}</span></div>
+                <div className="catch-stat-row"><span>총점</span><span className="catch-stat-value">{score >= 0 ? `+${score}` : score}</span></div>
+                <div className="catch-stat-row"><span>완벽 (+50)</span><span>{counts.perfect}</span></div>
+                <div className="catch-stat-row"><span>근접 (+20)</span><span>{counts.near}</span></div>
+                <div className="catch-stat-row"><span>실패 ({FAIL_PENALTY})</span><span>{counts.fail}</span></div>
+                <div className="catch-stat-row"><span>놓침 (0)</span><span>{counts.miss}</span></div>
                 <div className="catch-stat-row catch-stat-row-highlight"><span>판정 횟수</span><span>{totalJudged}</span></div>
               </div>
               <p className="catch-result-desc">{result.desc}</p>

--- a/src/components/CatchGame/catchUtils.js
+++ b/src/components/CatchGame/catchUtils.js
@@ -17,7 +17,7 @@ export const HIT_RANGE_MAX = 150;           // 이 범위 밖 입력은 fail로 
 export const ITEM_VISUAL_HEIGHT_PX = 50;
 
 export const GAME_DURATION_MS = 10_000;
-export const SPAWN_COUNT = 6;
+export const SPAWN_COUNT = 5;
 export const SPAWN_MIN_GAP_MS = 1400;
 export const SPAWN_MAX_GAP_MS = 1700;
 export const SPAWN_FIRST_AT_MS = 800;
@@ -25,11 +25,14 @@ export const FALL_DURATION_MS = 2000;
 export const STAGE_HEIGHT_PX = 600;
 export const RED_CIRCLE_TOP_RATIO = 0.7;    // stage height의 70% 지점 (제단 위치)
 
+// FAIL 시 패널티 (NEAR 범위 밖에서 → 누름 또는 HIT_RANGE_MAX 밖)
+export const FAIL_PENALTY = -10;
+
 // 거리(px)를 받아 점수와 종류 반환
 export function judgeHit(distancePx) {
   if (distancePx <= TARGET_DISTANCE_PERFECT) return { score: 50, kind: 'perfect' };
   if (distancePx <= TARGET_DISTANCE_NEAR) return { score: 20, kind: 'near' };
-  return { score: 0, kind: 'fail' };
+  return { score: FAIL_PENALTY, kind: 'fail' };
 }
 
 // 5개 spawn 만점 250 기준 5단계 등급 (다른 게임과 통일)

--- a/src/components/ColorReactionGame/ColorReactionGame.jsx
+++ b/src/components/ColorReactionGame/ColorReactionGame.jsx
@@ -3,7 +3,13 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { getReactionResult, getScore } from "./reactionUtils";
 import "./ColorReactionGame.css";
 
-export default function ColorReactionGame({ autoStart = false, onComplete, onContinue }) {
+export default function ColorReactionGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  onComplete,
+  onContinue,
+}) {
   const [phase, setPhase] = useState("idle");
   const [timeLeft, setTimeLeft] = useState(10.00);
   const [reactionTime, setReactionTime] = useState(0);
@@ -34,23 +40,26 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
     setTimeLeft(10.00);
     setReactionTime(0);
 
-    gameIntervalRef.current = setInterval(() => {
-      setTimeLeft((prev) => {
-        if (prev <= 0.01) {
-          endGame("timeout");
-          return 0;
-        }
-        return prev - 0.01;
-      });
-    }, 10);
+    // embedded 모드는 자체 10초 카운트다운 비활성 (마스터 타이머가 통제)
+    if (!embedded) {
+      gameIntervalRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 0.01) {
+            endGame("timeout");
+            return 0;
+          }
+          return prev - 0.01;
+        });
+      }, 10);
+    }
 
-    // 4초 ~ 10초 사이 랜덤한 시간에 눈에 불이 들어옴 (사용자 IDE 변경 반영)
+    // 4-10초 랜덤 대기 (마스터 15초 안에 react 윈도우 5~11초 확보)
     const randomDelay = Math.random() * 6000 + 4000;
     timeoutIdRef.current = setTimeout(() => {
       setPhase("react");
       glowStartTimeRef.current = performance.now();
     }, randomDelay);
-  }, [endGame]);
+  }, [endGame, embedded]);
 
   // 키보드: ↑ 반응, Space 시작(autoStart=false), Enter 다음으로
   useEffect(() => {
@@ -84,6 +93,21 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoStart]);
 
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 미보고 시 0점
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phase === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      // waiting 중이거나 react 못 누른 상태에서 마스터가 종료 → 0점
+      clearInterval(gameIntervalRef.current);
+      clearTimeout(timeoutIdRef.current);
+      setPhase('timeout');
+      completedRef.current = true;
+      onComplete?.(0);
+    }
+  }, [embedded, externalPhase, phase, startGame, onComplete]);
+
   useEffect(() => {
     return () => {
       clearInterval(gameIntervalRef.current);
@@ -100,7 +124,7 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
 
   return (
     <div className={`dungeon-world ${isGlowing ? "dungeon-alert" : ""}`}>
-      {(phase === "waiting" || phase === "react") && (
+      {!embedded && (phase === "waiting" || phase === "react") && (
         <div className="dungeon-timer">
           남은 시간: {timeLeft.toFixed(2)}s
         </div>
@@ -133,7 +157,7 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
       </div>
 
       <div className="dungeon-ui-overlay">
-        {phase === "idle" && !autoStart && (
+        {!embedded && phase === "idle" && !autoStart && (
           <div className="dungeon-panel start-panel">
             <h2 className="dungeon-title">🗿 침묵의 석상</h2>
             <p>석상의 눈에 <b>붉은 안광</b>이 서리면 ⬆️키를 누르세요!</p>
@@ -154,7 +178,7 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
           </div>
         )}
 
-        {phase === "early" && (
+        {!embedded && phase === "early" && (
           <div className="dungeon-panel error-panel">
             <h2>💥 끔찍한 죽음</h2>
             <p>석상이 빛나기 전에 움직였습니다!</p>
@@ -165,7 +189,7 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
           </div>
         )}
 
-        {phase === "timeout" && (
+        {!embedded && phase === "timeout" && (
           <div className="dungeon-panel error-panel">
             <h2>⏰ 시간 초과</h2>
             <p>던전이 무너져 내렸습니다.</p>
@@ -176,7 +200,7 @@ export default function ColorReactionGame({ autoStart = false, onComplete, onCon
           </div>
         )}
 
-        {phase === "result" && resultData && (
+        {!embedded && phase === "result" && resultData && (
           <div className="dungeon-panel result-panel">
             <h2 style={{ color: resultData.color }}>{resultData.title}</h2>
             <h1 className="reaction-time-text">{reactionTime} ms</h1>

--- a/src/components/ParallelGame/ParallelGame.css
+++ b/src/components/ParallelGame/ParallelGame.css
@@ -1,0 +1,262 @@
+/* 미니게임 4 — 결전의 서막 (병렬 진행) */
+
+.parallel-stage {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 60%, #0f172a 100%);
+  color: #e2e8f0;
+  overflow: hidden;
+}
+
+/* ─── Idle 패널 ─────────────────────────────── */
+.parallel-idle-panel {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  padding: 40px;
+  text-align: center;
+}
+.parallel-title {
+  font-size: 56px;
+  margin: 0;
+  color: #fbbf24;
+  text-shadow: 2px 2px 0 #000, 0 0 16px rgba(251, 191, 36, 0.5);
+}
+.parallel-subtitle {
+  font-size: 22px;
+  color: #94a3b8;
+  margin: 0 0 8px;
+}
+.parallel-area-cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  width: min(900px, 90%);
+}
+.parallel-area-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 2px solid #475569;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+.parallel-area-icon  { font-size: 40px; }
+.parallel-area-name  { font-size: 18px; font-weight: 700; }
+.parallel-area-key   { font-size: 14px; color: #fbbf24; }
+
+.parallel-bonus-note {
+  font-size: 18px;
+  color: #fbbf24;
+  margin: 0;
+}
+.parallel-grade-rules {
+  width: min(560px, 90%);
+}
+.parallel-start-btn {
+  margin-top: 12px;
+  padding: 14px 32px;
+  font-size: 20px;
+  font-weight: 700;
+  background: linear-gradient(180deg, #fbbf24, #d97706);
+  color: #1f2937;
+  border: 3px solid #92400e;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #78350f;
+}
+.parallel-start-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 #78350f;
+}
+.parallel-start-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #78350f;
+}
+
+/* ─── Running phase: HUD + 3분할 grid ─────── */
+.parallel-master-hud {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 64px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 32px;
+  background: rgba(15, 23, 42, 0.85);
+  border-bottom: 3px solid #fbbf24;
+  z-index: 10;
+}
+.parallel-master-title  { font-size: 22px; font-weight: 700; color: #fbbf24; }
+.parallel-master-timer  { font-size: 22px; font-weight: 700; color: #f1f5f9; font-variant-numeric: tabular-nums; }
+
+.parallel-grid {
+  position: absolute;
+  top: 64px;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 0;
+}
+.parallel-area {
+  position: relative;
+  overflow: hidden;
+  border-right: 2px solid rgba(251, 191, 36, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.parallel-area:last-child { border-right: none; }
+
+/* sub-game stage(1920x960) wrapper — 영역 height(896px)에 맞게 비례 축소.
+   sub-game의 좌표 시스템(STAGE_HEIGHT_PX 등)과 시각 매핑을 보존.
+   주의: 자식에게 width/height 100% 강제하지 않음 — catch-stage/dungeon-world의
+   자체 1200x600 + scale(1.6) 매핑이 깨지면 좌표/animation 불일치 발생. */
+.parallel-area-inner {
+  position: relative;
+  width: 1920px;
+  height: 960px;
+  flex-shrink: 0;
+  transform-origin: center center;
+  transform: scale(0.9333);
+}
+
+/* 영역 완료 오버레이 — sub-game이 점수를 보고하면 freeze 시각화 */
+.parallel-area-done-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: rgba(15, 23, 42, 0.88);
+  z-index: 4;
+  pointer-events: none;
+  width: 100%;
+  height: 100%;
+  animation: parallel-area-done-fade 0.25s ease-out;
+}
+.parallel-area-done-icon  { font-size: 64px; filter: drop-shadow(0 0 12px rgba(52, 211, 153, 0.6)); }
+.parallel-area-done-label { font-size: 22px; font-weight: 700; color: #34d399; letter-spacing: 1px; }
+.parallel-area-done-score { font-size: 32px; font-weight: 800; color: #fbbf24; }
+.parallel-area-done-wait  { font-size: 13px; color: #94a3b8; margin-top: 8px; }
+@keyframes parallel-area-done-fade {
+  from { opacity: 0; transform: scale(0.95); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* 키 가이드 배지 — 영역 상단 중앙에 항상 표시 */
+.parallel-area-key-badge {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 5;
+  width: auto;
+  height: auto;
+  padding: 6px 14px;
+  background: rgba(15, 23, 42, 0.92);
+  color: #fbbf24;
+  border: 2px solid #fbbf24;
+  border-radius: 999px;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  white-space: nowrap;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.6);
+}
+
+/* ─── Result 패널 ─────────────────────────── */
+.parallel-result-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 20;
+}
+.parallel-result-panel {
+  background: linear-gradient(180deg, #1e293b, #0f172a);
+  border: 3px solid var(--parallel-result-color, #fbbf24);
+  border-radius: 16px;
+  padding: 32px 40px;
+  max-width: 520px;
+  text-align: center;
+  box-shadow: 0 0 40px var(--parallel-result-color, #fbbf24);
+}
+.parallel-grade-badge {
+  display: inline-block;
+  padding: 6px 18px;
+  background: var(--parallel-result-color);
+  color: #1f2937;
+  font-weight: 700;
+  border-radius: 999px;
+  font-size: 14px;
+  letter-spacing: 1px;
+  margin-bottom: 12px;
+}
+.parallel-result-title {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 0 0 12px;
+}
+.parallel-stats {
+  margin: 20px 0 16px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.parallel-stat-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 16px;
+}
+.parallel-stat-row b { color: #fbbf24; }
+.parallel-stat-divider {
+  height: 1px;
+  background: rgba(255, 255, 255, 0.15);
+  margin: 4px 0;
+}
+.parallel-stat-row-highlight {
+  font-size: 20px;
+  font-weight: 700;
+}
+.parallel-stat-row-highlight b { color: var(--parallel-result-color); }
+.parallel-result-desc {
+  margin: 8px 0 16px;
+  color: #cbd5e1;
+}
+.parallel-continue-btn {
+  padding: 12px 28px;
+  font-size: 18px;
+  font-weight: 700;
+  background: linear-gradient(180deg, #fbbf24, #d97706);
+  color: #1f2937;
+  border: 3px solid #92400e;
+  border-radius: 8px;
+  cursor: pointer;
+  box-shadow: 0 4px 0 #78350f;
+}
+.parallel-continue-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 0 #78350f;
+}
+.parallel-continue-btn:active {
+  transform: translateY(2px);
+  box-shadow: 0 1px 0 #78350f;
+}

--- a/src/components/ParallelGame/ParallelGame.jsx
+++ b/src/components/ParallelGame/ParallelGame.jsx
@@ -1,0 +1,225 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import TenSecondsGame from '../TenSecondsGame/TenSecondsGame';
+import ColorReactionGame from '../ColorReactionGame/ColorReactionGame';
+import CatchGame from '../CatchGame/CatchGame';
+import StarRating from '../TenSecondsGame/StarRating';
+import { getParallelGrade, computeFinalScore } from './parallelUtils';
+import './ParallelGame.css';
+
+const MASTER_DURATION_MS = 15_000;
+
+export default function ParallelGame({ onComplete, onContinue }) {
+  const [phase, setPhase] = useState('idle'); // 'idle' | 'running' | 'result'
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [scoreLeft, setScoreLeft] = useState(null);
+  const [scoreCenter, setScoreCenter] = useState(null);
+  const [scoreRight, setScoreRight] = useState(null);
+
+  const startMsRef = useRef(0);
+  const rafRef = useRef(null);
+  const masterCompleteRef = useRef(false);
+  const resultCompleteRef = useRef(false);
+
+  const startMaster = useCallback(() => {
+    masterCompleteRef.current = false;
+    resultCompleteRef.current = false;
+    setScoreLeft(null);
+    setScoreCenter(null);
+    setScoreRight(null);
+    setElapsedMs(0);
+    setPhase('running');
+    startMsRef.current = performance.now();
+  }, []);
+
+  // 키보드: idle → Space/Enter 시작, result → Space/Enter 다음으로
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.code !== 'Space' && e.code !== 'Enter') return;
+      if (phase === 'idle') {
+        e.preventDefault();
+        startMaster();
+      } else if (phase === 'result') {
+        e.preventDefault();
+        onContinue?.();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [phase, startMaster, onContinue]);
+
+  // 마스터 타이머: phase 'running' 진입 시 RAF 루프
+  useEffect(() => {
+    if (phase !== 'running') return undefined;
+    const tick = () => {
+      const now = performance.now() - startMsRef.current;
+      setElapsedMs(now);
+      if (now >= MASTER_DURATION_MS) {
+        if (!masterCompleteRef.current) {
+          masterCompleteRef.current = true;
+          setPhase('result');
+        }
+        return;
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, [phase]);
+
+  // result 진입 시점: 모든 영역 onComplete 보고 후 합산하여 1회 onComplete 호출
+  // 각 sub-game이 externalPhase='result'를 받으면 즉시 onComplete?.(score|0)을 호출하도록
+  // Tasks 2-4에서 보장됨 — null이 영구히 남는 경우는 없다.
+  useEffect(() => {
+    if (phase !== 'result') return;
+    if (resultCompleteRef.current) return;
+    if (scoreLeft === null || scoreCenter === null || scoreRight === null) return;
+    resultCompleteRef.current = true;
+    const { total } = computeFinalScore(scoreLeft, scoreCenter, scoreRight);
+    onComplete?.(total);
+  }, [phase, scoreLeft, scoreCenter, scoreRight, onComplete]);
+
+  return (
+    <div className="parallel-stage">
+      {phase === 'idle' && (
+        <div className="parallel-idle-panel">
+          <h1 className="parallel-title">⚔️ 결전의 서막</h1>
+          <p className="parallel-subtitle">갑옷을 두른 그린이, 모든 시련을 한 번에</p>
+          <div className="parallel-area-cards">
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">⏱</div>
+              <div className="parallel-area-name">10초 맞추기</div>
+              <div className="parallel-area-key">← 키</div>
+            </div>
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">🗿</div>
+              <div className="parallel-area-name">침묵의 석상</div>
+              <div className="parallel-area-key">↑ 키</div>
+            </div>
+            <div className="parallel-area-card">
+              <div className="parallel-area-icon">⚔️</div>
+              <div className="parallel-area-name">장비 캐치</div>
+              <div className="parallel-area-key">→ 키 (속도 1.5×)</div>
+            </div>
+          </div>
+          <p className="parallel-bonus-note">3영역 합산 점수 <b>× 2배 보너스</b></p>
+          <div className="score-rules parallel-grade-rules">
+            <div className="score-rules-title">🏆 등급 (보너스 적용 후 점수)</div>
+            <div className="score-rule tier-legendary"><span>🌟 레전더리</span><b>≥ 900점</b></div>
+            <div className="score-rule tier-unique"><span>💎 유니크</span><b>≥ 750점</b></div>
+            <div className="score-rule tier-epic"><span>🔮 에픽</span><b>≥ 550점</b></div>
+            <div className="score-rule tier-rare"><span>⚔️ 레어</span><b>≥ 300점</b></div>
+            <div className="score-rule tier-common"><span>🛡️ 일반</span><b>&lt; 300점</b></div>
+          </div>
+          <button type="button" className="parallel-start-btn" onClick={startMaster}>
+            ▶ 결전 시작 (Space / Enter)
+          </button>
+        </div>
+      )}
+      {(phase === 'running' || phase === 'result') && (
+        <>
+          <div className="parallel-master-hud">
+            <span className="parallel-master-title">⚔️ 결전의 서막</span>
+            <span className="parallel-master-timer">
+              남은 시간 {Math.max(0, (MASTER_DURATION_MS - elapsedMs) / 1000).toFixed(1)}s
+            </span>
+          </div>
+          <div className="parallel-grid">
+            <div className="parallel-area parallel-area-left">
+              <div className="parallel-area-key-badge">← 10초 맞추기</div>
+              <div className="parallel-area-inner">
+                <TenSecondsGame
+                  embedded
+                  externalPhase={phase}
+                  onComplete={(score) => setScoreLeft(score)}
+                />
+              </div>
+              {phase === 'running' && scoreLeft !== null && (
+                <div className="parallel-area-done-overlay">
+                  <div className="parallel-area-done-icon">✅</div>
+                  <div className="parallel-area-done-label">완료</div>
+                  <div className="parallel-area-done-score">+{scoreLeft}</div>
+                  <div className="parallel-area-done-wait">다른 영역 대기 중…</div>
+                </div>
+              )}
+            </div>
+            <div className="parallel-area parallel-area-center">
+              <div className="parallel-area-key-badge">↑ 색상 반응</div>
+              <div className="parallel-area-inner">
+                <ColorReactionGame
+                  embedded
+                  externalPhase={phase}
+                  onComplete={(score) => setScoreCenter(score)}
+                />
+              </div>
+              {phase === 'running' && scoreCenter !== null && (
+                <div className="parallel-area-done-overlay">
+                  <div className="parallel-area-done-icon">✅</div>
+                  <div className="parallel-area-done-label">완료</div>
+                  <div className="parallel-area-done-score">{scoreCenter >= 0 ? `+${scoreCenter}` : scoreCenter}</div>
+                  <div className="parallel-area-done-wait">다른 영역 대기 중…</div>
+                </div>
+              )}
+            </div>
+            <div className="parallel-area parallel-area-right">
+              <div className="parallel-area-key-badge">→ 캐치 (1.5×)</div>
+              <div className="parallel-area-inner">
+                <CatchGame
+                  embedded
+                  externalPhase={phase}
+                  speedMultiplier={1.5}
+                  onComplete={(score) => setScoreRight(score)}
+                />
+              </div>
+              {phase === 'running' && scoreRight !== null && (
+                <div className="parallel-area-done-overlay">
+                  <div className="parallel-area-done-icon">✅</div>
+                  <div className="parallel-area-done-label">완료</div>
+                  <div className="parallel-area-done-score">{scoreRight >= 0 ? `+${scoreRight}` : scoreRight}</div>
+                  <div className="parallel-area-done-wait">다른 영역 대기 중…</div>
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+      {phase === 'result' && (() => {
+        const l = scoreLeft ?? 0;
+        const c = scoreCenter ?? 0;
+        const r = scoreRight ?? 0;
+        const { raw, total } = computeFinalScore(l, c, r);
+        const grade = getParallelGrade(total);
+        return (
+          <div className="parallel-result-overlay">
+            <div
+              className="parallel-result-panel"
+              style={{ '--parallel-result-color': grade.color }}
+            >
+              <div className="parallel-grade-badge" data-grade={grade.grade}>{grade.grade}</div>
+              <div className="parallel-result-title" style={{ color: grade.color }}>{grade.title}</div>
+              <StarRating count={grade.stars} />
+
+              <div className="parallel-stats">
+                <div className="parallel-stat-row"><span>좌 (10초 맞추기)</span><b>+{l}</b></div>
+                <div className="parallel-stat-row"><span>중 (색상 반응)</span><b>{c >= 0 ? `+${c}` : c}</b></div>
+                <div className="parallel-stat-row"><span>우 (캐치 1.5×)</span><b>{r >= 0 ? `+${r}` : r}</b></div>
+                <div className="parallel-stat-divider" />
+                <div className="parallel-stat-row"><span>합산</span><b>+{raw}</b></div>
+                <div className="parallel-stat-row"><span>× 2 보너스</span><b>+{total}</b></div>
+                <div className="parallel-stat-divider" />
+                <div className="parallel-stat-row parallel-stat-row-highlight">
+                  <span>최종 점수</span><b>+{total}</b>
+                </div>
+              </div>
+              <p className="parallel-result-desc">{grade.desc}</p>
+              <button type="button" className="parallel-continue-btn" onClick={onContinue}>
+                다음으로 (Enter / Space)
+              </button>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/src/components/ParallelGame/parallelUtils.js
+++ b/src/components/ParallelGame/parallelUtils.js
@@ -1,0 +1,42 @@
+// 미니게임 4 (병렬 진행) — 합산 점수 → 5단계 등급 산정
+// 등급 임계치는 절대 점수 기준 (랭킹전이라 점수 상한 미고지)
+export const PARALLEL_GRADES = [
+  { grade: 'LEGENDARY', threshold: 900, stars: 5, color: '#ffd700', title: '🌟 결전의 영웅', desc: '갑옷 입은 그린이의 모든 능력이 폭발했다.' },
+  { grade: 'UNIQUE',    threshold: 750, stars: 4, color: '#ff007f', title: '💎 갑옷의 수호자', desc: '훌륭한 종합 시험. 보스 앞에서도 흔들리지 않으리라.' },
+  { grade: 'EPIC',      threshold: 550, stars: 3, color: '#a78bfa', title: '🔮 결전의 전사', desc: '준비는 충분하다. 보스를 향해 나아가자.' },
+  { grade: 'RARE',      threshold: 300, stars: 2, color: '#60a5fa', title: '⚔️ 시련의 통과자', desc: '아슬아슬하게 시련을 통과했다.' },
+  { grade: 'COMMON',    threshold: 0,   stars: 1, color: '#86efac', title: '🛡️ 새내기 전사', desc: '아직 부족하지만 보스를 향한 첫 발은 뗐다.' },
+];
+
+export function getParallelGrade(totalBonus) {
+  const score = Math.max(0, totalBonus);
+  return PARALLEL_GRADES.find((g) => score >= g.threshold);
+}
+
+// 합산 점수 (보너스 적용 전/후) 산출
+export function computeFinalScore(scoreLeft, scoreCenter, scoreRight, bonus = 2) {
+  const raw = Math.max(0, (scoreLeft ?? 0) + (scoreCenter ?? 0) + (scoreRight ?? 0));
+  return { raw, total: raw * bonus };
+}
+
+// dev 환경 자체 검증 (console.assert)
+if (import.meta.env?.DEV) {
+  console.assert(getParallelGrade(1000).grade === 'LEGENDARY', 'parallelUtils: 1000 → LEGENDARY');
+  console.assert(getParallelGrade(900).grade === 'LEGENDARY', 'parallelUtils: 900 → LEGENDARY');
+  console.assert(getParallelGrade(899).grade === 'UNIQUE',    'parallelUtils: 899 → UNIQUE');
+  console.assert(getParallelGrade(750).grade === 'UNIQUE',    'parallelUtils: 750 → UNIQUE');
+  console.assert(getParallelGrade(749).grade === 'EPIC',      'parallelUtils: 749 → EPIC');
+  console.assert(getParallelGrade(550).grade === 'EPIC',      'parallelUtils: 550 → EPIC');
+  console.assert(getParallelGrade(549).grade === 'RARE',      'parallelUtils: 549 → RARE');
+  console.assert(getParallelGrade(300).grade === 'RARE',      'parallelUtils: 300 → RARE');
+  console.assert(getParallelGrade(299).grade === 'COMMON',    'parallelUtils: 299 → COMMON');
+  console.assert(getParallelGrade(0).grade === 'COMMON',      'parallelUtils: 0 → COMMON');
+  console.assert(getParallelGrade(-100).grade === 'COMMON',   'parallelUtils: -100 → COMMON (clamp)');
+  const f = computeFinalScore(100, 100, 300);
+  console.assert(f.raw === 500 && f.total === 1000, 'parallelUtils: max raw 500, total 1000');
+  const fNeg = computeFinalScore(100, -20, 300);
+  console.assert(fNeg.raw === 380 && fNeg.total === 760, 'parallelUtils: 개별 음수 입력 합산 380 (합산 양수 → 클램프 미적용)');
+  // 합산이 실제로 음수인 케이스 (ColorReaction -20만 있고 나머지 0) → raw 0으로 클램프
+  const fAllNeg = computeFinalScore(0, -20, 0);
+  console.assert(fAllNeg.raw === 0 && fAllNeg.total === 0, 'parallelUtils: 합산 음수 → raw 0으로 클램프, total 0');
+}

--- a/src/components/TenSecondsGame/TenSecondsGame.jsx
+++ b/src/components/TenSecondsGame/TenSecondsGame.jsx
@@ -5,7 +5,13 @@ import { Clouds, FarBg, Trees } from "./BackgroundElements";
 import StarRating from "./StarRating";
 import "./TenSecondsGame.css";
 
-export default function TenSecondsGame({ autoStart = false, onComplete, onContinue }) {
+export default function TenSecondsGame({
+  autoStart = false,
+  embedded = false,
+  externalPhase,
+  onComplete,
+  onContinue,
+}) {
   const [phase, setPhase] = useState("idle");
   const [elapsed, setElapsed] = useState(0);
   const [finalTime, setFinalTime] = useState(null);
@@ -58,6 +64,20 @@ export default function TenSecondsGame({ autoStart = false, onComplete, onContin
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoStart]);
 
+  // embedded 모드: externalPhase 'running' → 자동 시작, 'result' → 미보고 시 0점
+  useEffect(() => {
+    if (!embedded || !externalPhase) return;
+    if (externalPhase === 'running' && phase === 'idle') {
+      startGame();
+    } else if (externalPhase === 'result' && !completedRef.current) {
+      // 사용자가 ← 안 누르고 마스터 타이머가 종료된 케이스 → 0점 보고
+      cancelAnimationFrame(rafRef.current);
+      setPhase('result');
+      completedRef.current = true;
+      onComplete?.(0);
+    }
+  }, [embedded, externalPhase, phase, startGame, onComplete]);
+
   // 키보드: ← 정지, Space 시작(autoStart=false일 때만), Enter 다음으로(result + onContinue)
   useEffect(() => {
     const onKey = (e) => {
@@ -81,7 +101,7 @@ export default function TenSecondsGame({ autoStart = false, onComplete, onContin
 
   useEffect(() => () => cancelAnimationFrame(rafRef.current), []);
 
-  const displayTime = phase === "result" ? finalTime : elapsed;
+  const displayTime = phase === "result" ? (finalTime ?? elapsed) : elapsed;
   const diff = finalTime !== null ? Math.abs(finalTime - TARGET) : null;
   const result = diff !== null ? getResult(diff) : null;
   const score = diff !== null ? getScore(diff) : null;
@@ -117,7 +137,7 @@ export default function TenSecondsGame({ autoStart = false, onComplete, onContin
             <span className="sign-text">10초  맞추기</span>
             <span className="sign-icon">⏱</span>
           </div>
-          <p className="sign-subtitle">그린이의 시련 — 정확히 10.00초에 멈춰라!</p>
+          {!embedded && <p className="sign-subtitle">그린이의 시련 — 정확히 10.00초에 멈춰라!</p>}
 
           <div className={`timer-board ${timerUrgency}`}>
             <div className="timer-inner">
@@ -128,36 +148,38 @@ export default function TenSecondsGame({ autoStart = false, onComplete, onContin
             <div className="timer-label">ELAPSED TIME</div>
           </div>
 
-          <div className="controls-area">
-            {phase === "idle" && !autoStart && (
-              <button className="pixel-btn pixel-btn-green" onClick={startGame}>
-                <span>▶ 시작 (← 키)</span>
-              </button>
-            )}
-            {phase === "running" && (
-              <button className="pixel-btn pixel-btn-red" onClick={stopGame}>
-                <span>◼ 정지 (← 방향키)</span>
-              </button>
-            )}
-            {phase === "result" && (
-              onContinue ? (
-                <button className="pixel-btn pixel-btn-yellow" onClick={onContinue}>
-                  <span>다음으로 (Enter / Space)</span>
+          {!embedded && (
+            <div className="controls-area">
+              {phase === "idle" && !autoStart && (
+                <button className="pixel-btn pixel-btn-green" onClick={startGame}>
+                  <span>▶ 시작 (← 키)</span>
                 </button>
-              ) : (
-                <div className="result-btns">
-                  <button className="pixel-btn pixel-btn-yellow" onClick={startGame}>
-                    <span>▶ 다시하기 (Space)</span>
+              )}
+              {phase === "running" && (
+                <button className="pixel-btn pixel-btn-red" onClick={stopGame}>
+                  <span>◼ 정지 (← 방향키)</span>
+                </button>
+              )}
+              {phase === "result" && (
+                onContinue ? (
+                  <button className="pixel-btn pixel-btn-yellow" onClick={onContinue}>
+                    <span>다음으로 (Enter / Space)</span>
                   </button>
-                  <button className="pixel-btn pixel-btn-gray" onClick={resetGame}>
-                    <span>↩ 처음으로</span>
-                  </button>
-                </div>
-              )
-            )}
-          </div>
+                ) : (
+                  <div className="result-btns">
+                    <button className="pixel-btn pixel-btn-yellow" onClick={startGame}>
+                      <span>▶ 다시하기 (Space)</span>
+                    </button>
+                    <button className="pixel-btn pixel-btn-gray" onClick={resetGame}>
+                      <span>↩ 처음으로</span>
+                    </button>
+                  </div>
+                )
+              )}
+            </div>
+          )}
 
-          {phase === "idle" && !autoStart && (
+          {!embedded && phase === "idle" && !autoStart && (
             <>
               <p className="hint-text">← 키로 타이머를 시작하고,<br />다시 ← 방향키로 정확히 10.00초에 멈추세요!</p>
               <div className="score-rules">
@@ -170,13 +192,13 @@ export default function TenSecondsGame({ autoStart = false, onComplete, onContin
               </div>
             </>
           )}
-          {phase === "running" && (
+          {!embedded && phase === "running" && (
             <p className="hint-text running-hint">
               {displayTime >= 9 ? "🚨 지금이다! 멈춰!!!" : displayTime >= 7 ? "⚠️ 슬슬 준비해..." : "타이머가 흘러가고 있다..."}
             </p>
           )}
 
-          {phase === "result" && result && (
+          {!embedded && phase === "result" && result && (
             <div className="result-panel" style={{ "--result-color": result.color }}>
               <div className="result-grade-badge" data-grade={result.grade}>{result.grade}</div>
               <div className="result-title" style={{ color: result.color }}>{result.title}</div>


### PR DESCRIPTION
## ✨ 변경 사항
--- 
### 📌 작업 개요

PRD §2.4 명세에 따라 1·2·3번 미니게임을 한 화면에서 동시 진행하는 미니게임 4 **"결전의 서막"** 구현. 이전 placeholder만 있던 클라이맥스 단계를 실제 게임 로직으로 채움. 갑옷을 두른 그린이가 모든 시련을 한 번에 받는 종합 시험.

**보고서 파일**: `.report/20260505_#16_미니게임4_결전의_서막_병렬진행_구현.md`

---

### 🎯 구현 목표

- 좌·중·우 3분할 레이아웃으로 1·2·3번 미니게임 동시 진행
- 마스터 타이머 15초 (1번 게임 만점 윈도우 보장)
- 합산 점수 × 2배 보너스 적용
- 캐치 영역 1.5배 속도 + 입력 5번 한도
- 5단계 등급 시스템 (레전더리/유니크/에픽/레어/일반)
- App.jsx 라우터에서 minigame_4 placeholder를 실제 컴포넌트로 교체
- onContinue → boss_fight 씬 전환

---

### ✅ 구현 내용

#### ParallelGame 신규 구현 (마스터 오케스트레이터)
- **파일**: `src/components/ParallelGame/ParallelGame.jsx`, `ParallelGame.css`, `parallelUtils.js`
- **변경 내용**: phase 'idle'/'running'/'result' 상태 머신 + RAF 마스터 타이머 15초 + 3분할 grid + 영역별 ✅ 완료 오버레이 + 결과 패널
- **이유**: 3개의 sub-game을 외부에서 통제하면서 동시 시작/종료, 점수 집계, 등급 산정을 한 곳에서 관리

#### 기존 1·2·3번 게임에 embedded 모드 추가
- **파일**: `src/components/TenSecondsGame/TenSecondsGame.jsx`, `ColorReactionGame/ColorReactionGame.jsx`, `CatchGame/CatchGame.jsx`
- **변경 내용**: `embedded`, `externalPhase` prop 추가. embedded일 때 자체 idle/result 패널 숨김 + 자체 종료 타이머 비활성 + externalPhase 'result' 수신 시 미보고 0점 처리
- **이유**: 단독 모드 동작은 그대로 유지하면서, ParallelGame이 외부에서 phase를 주입해 sub-game 라이프사이클을 통제할 수 있도록

#### 캐치 게임 룰 강화
- **파일**: `src/components/CatchGame/CatchGame.jsx`, `catchUtils.js`
- **변경 내용**: FAIL 패널티 -10점 + 의미 있는 → 입력 5번 한도 + HUD에 '기회 X/5' 표시 + SPAWN_COUNT 5로 정정
- **이유**: 게임성 강화 (잘못 누르면 패널티) + 입력 횟수 한도로 게임 템포 조절. 5번 도달 시 즉시 종료

#### App.jsx 라우팅 교체
- **파일**: `src/App.jsx`
- **변경 내용**: `state.scene === 'minigame_4'` 분기를 PlaceholderScene → `<ParallelGame />`로 교체. onContinue 대상도 'world' → 'boss_fight'
- **이유**: 실제 미니게임 4 구현 후 직접 보스전으로 이어지는 자연스러운 흐름

---

### 🔧 주요 변경사항 상세

#### parallelUtils.js
- `getParallelGrade(totalBonus)`: 5단계 등급 산정. LEGENDARY ≥ 900 / UNIQUE ≥ 750 / EPIC ≥ 550 / RARE ≥ 300 / COMMON
- `computeFinalScore(L, C, R, bonus=2)`: 음수 클램프 후 합산 × 2 보너스
- dev 환경 `console.assert` 자체 검증 (등급 경계값 + 음수 클램프 케이스)

**특이사항**:
- 등급 임계치는 절대 점수 기준 (max 표기 없음 — 랭킹전 컨셉)
- 음수 합산이 들어와도 클램프로 안전 처리 (ColorReaction 일찍 누름 -20점 케이스)

#### ParallelGame.jsx — race condition 방지
result 진입 effect가 모든 영역(`scoreLeft/Center/Right`) 보고 후에만 `onComplete(total)` 1회 발화하도록 가드.

**특이사항**:
- 마스터 RAF 타이머가 setPhase('result') 부른 시점에는 sub-game 들의 setState가 batch 상태라 score state가 아직 null. 이 race를 null-가드로 차단
- `resultCompleteRef`로 1회 한정 + `startMaster`에서 ref 리셋

#### ParallelGame.css — 좌표↔시각 매핑 보존
- `.parallel-area-inner` 1920×960 wrapper에 `transform: scale(0.9333)`로 영역 height(896px) fit
- 자식에게 width/height 100% 강제하지 않음 (sub-game 자체 1200×600 + scale(1.6) 매핑 유지)

**특이사항**:
- 초기 구현에서 자식에 width/height 100% 강제했더니 catch-stage가 stretch되어 animation은 600px만 이동하는데 stage 시각 height가 1536px이 되어 빨간 원에 도달 못함 → 캐치했는데 FAIL 뜨는 버그 발생. wrapper 룰 제거로 해결

#### CatchGame.jsx — 입력 5번 한도
```js
inputCountRef.current += 1;
setInputCount(inputCountRef.current);
// ... score/feedback 처리
if (inputCountRef.current >= MAX_INPUTS) {
  cleanupTimers();
  setPhase('result');
  if (!completedRef.current) {
    completedRef.current = true;
    onComplete?.(scoreRef.current);
  }
}
```

**특이사항**:
- 의미 있는 입력만 카운트 (`items.length === 0`일 땐 무시)
- `MAX_INPUTS = SPAWN_COUNT(5)` — 단일 진실의 원천
- 단독 모드와 embedded 모드 둘 다 같은 룰 적용

#### TenSecondsGame.jsx — null guard
embedded에서 externalPhase='result' 도달 시점에 사용자가 ← 안 누르고 있으면 finalTime이 null. 기존 `displayTime = phase === "result" ? finalTime : elapsed`가 timer-board에서 `null.toFixed(2)` crash. `finalTime ?? elapsed`로 fallback.

#### ColorReactionGame.jsx — embedded 대기
- embedded 모드에서 자체 10초 카운트다운 비활성화 (마스터 타이머가 통제)
- 대기 시간 4-10초 유지 (마스터 15초 안에 react 윈도우 5~11초 보장)

---

### 📦 의존성 변경
없음. 기존 React 19 + Vite 8만 사용.

---

### 🧪 테스트 및 검증

#### 자동 검증
- `vite build` 통과 (44 modules, 235 kB JS / 37 kB CSS)
- `parallelUtils.js`의 dev `console.assert` 자체 검증 통과 (등급 경계값 + 음수 클램프)

#### 수동 시나리오 (브라우저)
1. 만점 근접: 합산 ≈ 500 ×2 = 1000 → LEGENDARY
2. 1번 미입력: 0+100+250 = 350 ×2 = 700 → UNIQUE
3. 2번 일찍 누름: 100+(-20)+250 = 330 ×2 = 660 → EPIC (음수 클램프 확인)
4. 모두 0점: → COMMON
5. ←↑→ 동시 입력: 각 영역 분리 처리
6. result 패널 Enter → boss_fight 전환

#### 단독 모드 회귀
1·2·3번 stage 단독 진입 시 embedded=false 기본값 → 기존 idle/result 패널 + 자체 키 동작 정상.

---

### 📌 참고사항

#### 마스터 타이머 15초 채택 이유
1번 게임 만점 윈도우는 ±0.05초 (9.95~10.05초). 마스터를 10초로 cut하면 후반 절반(10.00~10.05초)이 잘려 사용자가 "분명 잘 눌렀는데 0점!?" frustration. 15초로 늘려 만점 윈도우 안전 보장 + 캐치 5번 입력 여유 + 색상 반응 react 윈도우 확보.

#### 일찍 끝낸 영역의 freeze UX
1번을 9초쯤에 ←, 2번을 4초에 ↑로 끝내면 그 영역은 마스터 종료까지 freeze. 이를 시각화하기 위해 ✅ 완료 오버레이 + "다른 영역 대기 중…" 표시. 음수 점수(-20)도 부호 그대로 표시.

#### 등급 임계치 기준
- 합산 max 500 + ×2 = 1000을 기준으로 90/75/55/30% 임계치
- 단, idle 패널에서 max 점수 표기는 제거 (랭킹전 컨셉이라 점수 상한 미고지)

#### 후속 작업 권장
- 캐치 게임 `rightKeyArmedRef` 가드가 keydown handler에서 미사용 (사전 존재 코드, 영향은 적음)
- 사전 존재하는 repo eslint config에 `eslint-plugin-import-x` 미등록 → `npm run lint` 실행 불가. 별도 이슈로 해결 필요
- vitest 테스트 인프라 미도입 → 현재 console.assert로 대체. 후속 이슈로 정식 단위 테스트 이관 권장

---

### 📂 변경 파일 목록

```
docs/superpowers/specs/2026-05-05-minigame-4-parallel-design.md  (신규)
docs/superpowers/plans/2026-05-05-minigame-4-parallel.md         (신규)
src/components/ParallelGame/ParallelGame.jsx                     (신규)
src/components/ParallelGame/ParallelGame.css                     (신규)
src/components/ParallelGame/parallelUtils.js                     (신규)
src/components/TenSecondsGame/TenSecondsGame.jsx                 (수정)
src/components/ColorReactionGame/ColorReactionGame.jsx           (수정)
src/components/CatchGame/CatchGame.jsx                           (수정)
src/components/CatchGame/catchUtils.js                           (수정)
src/App.jsx                                                       (수정)
```



## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료
